### PR TITLE
Replace all instances of `yaml.safeLoad` because all other CI's are broken now

### DIFF
--- a/src/graphs.ts
+++ b/src/graphs.ts
@@ -1,5 +1,5 @@
 import { mkdirp, readFile, remove } from "fs-extra";
-import { safeLoad } from "js-yaml";
+import { load } from "js-yaml";
 import { join } from "path";
 import { exec } from "shelljs";
 import { commit, push } from "./helpers/git";
@@ -11,7 +11,7 @@ export const generateGraphs = async () => {
   if (!(await shouldContinue())) return;
   await mkdirp("graphs");
   await mkdirp("api");
-  const config = safeLoad(await readFile(join(".", ".upptimerc.yml"), "utf8")) as UpptimeConfig;
+  const config = load(await readFile(join(".", ".upptimerc.yml"), "utf8")) as UpptimeConfig;
   exec("npx @upptime/graphs");
   exec("npx imagemin-cli graphs/* --out-dir=graphs");
   try {

--- a/src/helpers/calculate-uptime.ts
+++ b/src/helpers/calculate-uptime.ts
@@ -1,6 +1,6 @@
 import dayjs from "dayjs";
 import { readFile } from "fs-extra";
-import { safeLoad } from "js-yaml";
+import { load } from "js-yaml";
 import { join } from "path";
 import { DownPecentages, Downtimes, SiteHistory } from "../interfaces";
 import { getOctokit } from "./github";
@@ -90,7 +90,7 @@ const getDowntimeSecondsForSite = async (slug: string): Promise<Downtimes> => {
  * @param slug - Slug of the site
  */
 export const getUptimePercentForSite = async (slug: string): Promise<DownPecentages> => {
-  const site = safeLoad(
+  const site = load(
     (await readFile(join(".", "history", `${slug}.yml`), "utf8"))
       .split("\n")
       .map((line) => (line.startsWith("- ") ? line.replace("- ", "") : line))

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,6 +1,6 @@
 import slugify from "@sindresorhus/slugify";
 import { mkdirp, readFile, writeFile } from "fs-extra";
-import { safeLoad } from "js-yaml";
+import { load } from "js-yaml";
 import { join } from "path";
 import { getConfig } from "./helpers/config";
 import { commit, lastCommit, push } from "./helpers/git";
@@ -27,7 +27,7 @@ export const update = async (shouldCommit = false) => {
     let currentStatus = "unknown";
     let startTime = new Date();
     try {
-      const siteHistory = safeLoad(
+      const siteHistory = load(
         (await readFile(join(".", "history", `${slug}.yml`), "utf8"))
           .split("\n")
           .map((line) => (line.startsWith("- ") ? line.replace("- ", "") : line))
@@ -129,7 +129,7 @@ export const update = async (shouldCommit = false) => {
       if (shouldCommit || currentStatus !== status) {
         await writeFile(
           join(".", "history", `${slug}.yml`),
-          `url: ${site.url}  
+          `url: ${site.url}
 status: ${status}
 code: ${result.httpCode}
 responseTime: ${responseTime}


### PR DESCRIPTION
Similarly to https://github.com/upptime/uptime-monitor/pull/86, the `safeLoad` function should be replaced for all other CI's