### PR TITLE
Accept a 0 value for maxRedirects

### DIFF
--- a/dist/helpers/request.js
+++ b/dist/helpers/request.js
@@ -18,7 +18,7 @@ const curl = (site) => new Promise((resolve) => {
     if (site.__dangerous__insecure || site.__dangerous__disable_verify_host)
         curl.setOpt("SSL_VERIFYHOST", false);
     curl.setOpt("FOLLOWLOCATION", 1);
-    curl.setOpt("MAXREDIRS", site.maxRedirects || 3);
+    curl.setOpt("MAXREDIRS", Number.isInteger(site.maxRedirects) ? site.maxRedirects : 3);
     curl.setOpt("USERAGENT", "Koj Bot");
     curl.setOpt("CONNECTTIMEOUT", 10);
     curl.setOpt("TIMEOUT", 30);

--- a/src/helpers/request.ts
+++ b/src/helpers/request.ts
@@ -19,7 +19,7 @@ export const curl = (
     if (site.__dangerous__insecure || site.__dangerous__disable_verify_host)
       curl.setOpt("SSL_VERIFYHOST", false);
     curl.setOpt("FOLLOWLOCATION", 1);
-    curl.setOpt("MAXREDIRS", site.maxRedirects || 3);
+    curl.setOpt("MAXREDIRS", Number.isInteger(site.maxRedirects) ? site.maxRedirects : 3);
     curl.setOpt("USERAGENT", "Koj Bot");
     curl.setOpt("CONNECTTIMEOUT", 10);
     curl.setOpt("TIMEOUT", 30);


### PR DESCRIPTION
Since zero is "falsy", it would not be accepted and the default of 3
would be used. This change verifies that the input is an integer value
instead, which is more robust and handles this use case.

Fixes upptime/upptime#127