### PR TITLE
Converting back to GH_PAT

### DIFF
--- a/src/workflows/graphs.yml
+++ b/src/workflows/graphs.yml
@@ -23,10 +23,10 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
       - name: Generate graphs
         uses: upptime/uptime-monitor@UPTIME_MONITOR_VERSION
         with:
           command: "graphs"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.GH_PAT }}

--- a/src/workflows/response-time.yml
+++ b/src/workflows/response-time.yml
@@ -23,11 +23,11 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
       - name: Update response time
         uses: upptime/uptime-monitor@UPTIME_MONITOR_VERSION
         with:
           command: "response-time"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.GH_PAT }}
           SECRETS_CONTEXT: ${{ toJson(secrets) }}

--- a/src/workflows/setup.yml
+++ b/src/workflows/setup.yml
@@ -24,39 +24,39 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
       - name: Update template
         uses: upptime/uptime-monitor@UPTIME_MONITOR_VERSION
         with:
           command: "update-template"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.GH_PAT }}
       - name: Update response time
         uses: upptime/uptime-monitor@UPTIME_MONITOR_VERSION
         with:
           command: "response-time"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.GH_PAT }}
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
       - name: Update summary in README
         uses: upptime/uptime-monitor@UPTIME_MONITOR_VERSION
         with:
           command: "readme"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.GH_PAT }}
       - name: Generate graphs
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: Graphs CI
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
       - name: Generate site
         uses: upptime/uptime-monitor@UPTIME_MONITOR_VERSION
         with:
           command: "site"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.GH_PAT }}
       - uses: maxheld83/ghpages@v0.3.0
         name: GitHub Pages Deploy
         env:
           BUILD_DIR: "site/status-page/__sapper__/export/"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/src/workflows/site.yml
+++ b/src/workflows/site.yml
@@ -22,15 +22,15 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
       - name: Generate site
         uses: upptime/uptime-monitor@UPTIME_MONITOR_VERSION
         with:
           command: "site"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.GH_PAT }}
       - uses: maxheld83/ghpages@v0.3.0
         name: GitHub Pages Deploy
         env:
           BUILD_DIR: "site/status-page/__sapper__/export/"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.GH_PAT }}

--- a/src/workflows/summary.yml
+++ b/src/workflows/summary.yml
@@ -23,17 +23,17 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
       - name: Update summary in README
         uses: upptime/uptime-monitor@UPTIME_MONITOR_VERSION
         with:
           command: "readme"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.GH_PAT }}
       - name: Run readme-repos-list
         uses: koj-co/readme-repos-list@master
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
           query: "topic:upptime"
           size: 15
           max: 1000

--- a/src/workflows/update-template.yml
+++ b/src/workflows/update-template.yml
@@ -23,10 +23,10 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
       - name: Update template
         uses: upptime/uptime-monitor@master
         with:
           command: "update-template"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.GH_PAT }}

--- a/src/workflows/updates.yml
+++ b/src/workflows/updates.yml
@@ -21,8 +21,8 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
       - name: Update code
         uses: upptime/updates@master
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.GH_PAT }}

--- a/src/workflows/uptime.yml
+++ b/src/workflows/uptime.yml
@@ -21,11 +21,11 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
       - name: Check endpoint status
         uses: upptime/uptime-monitor@UPTIME_MONITOR_VERSION
         with:
           command: "update"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.GH_PAT }}
           SECRETS_CONTEXT: ${{ toJson(secrets) }}


### PR DESCRIPTION
It seems that the automated tools, which *should* have replaced all `GITHUB_TOKEN` back to `GH_PAT` did not work (de26db30a85c242b8e7106b8bbd68e8398dca6eb), which has broken my repositories. It's also caused these issues:

https://github.com/upptime/upptime/issues/287

https://github.com/upptime/upptime/issues/286

Merging this should fix theses issues. If this was intended to be `GITHUB_TOKEN`, please update documentation.

Thanks! 