### PR TITLE
Fix bug calling Github API using outdated @octokit/rest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@actions/core": "^1.2.6",
         "@actions/github": "^4.0.0",
         "@koj/config": "^1.2.11",
+        "@octokit/rest": "^18.5.2",
         "@sindresorhus/slugify": "^1.1.0",
         "axios": "^0.21.1",
         "dayjs": "^1.10.4",
@@ -58,19 +59,6 @@
         "@octokit/plugin-rest-endpoint-methods": "^4.0.0"
       }
     },
-    "node_modules/@actions/github/node_modules/@octokit/core": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.1.2.tgz",
-      "integrity": "sha512-AInOFULmwOa7+NFi9F8DlDkm5qtZVmDQayi7TUgChE3yeIGPq0Y+6cAEXPexQ3Ea+uZy66hKEazR7DJyU+4wfw==",
-      "dependencies": {
-        "@octokit/auth-token": "^2.4.0",
-        "@octokit/graphql": "^4.3.1",
-        "@octokit/request": "^5.4.0",
-        "@octokit/types": "^5.0.0",
-        "before-after-hook": "^2.1.0",
-        "universal-user-agent": "^6.0.0"
-      }
-    },
     "node_modules/@actions/github/node_modules/@octokit/plugin-rest-endpoint-methods": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.1.2.tgz",
@@ -79,11 +67,6 @@
         "@octokit/types": "^5.1.1",
         "deprecation": "^2.3.1"
       }
-    },
-    "node_modules/@actions/github/node_modules/universal-user-agent": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
     },
     "node_modules/@actions/http-client": {
       "version": "1.0.8",
@@ -1593,24 +1576,41 @@
       }
     },
     "node_modules/@octokit/auth-token": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
-      "integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
+      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
       "dependencies": {
-        "@octokit/types": "^5.0.0"
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "node_modules/@octokit/auth-token/node_modules/@octokit/types": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
+      "integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
+      "dependencies": {
+        "@octokit/openapi-types": "^6.0.0"
       }
     },
     "node_modules/@octokit/core": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.5.4.tgz",
-      "integrity": "sha512-HCp8yKQfTITYK+Nd09MHzAlP1v3Ii/oCohv0/TW9rhSLvzb98BOVs2QmVYuloE6a3l6LsfyGIwb6Pc4ycgWlIQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-6/vlKPP8NF17cgYXqucdshWqmMZGXkuvtcrWCgU5NOI0Pl2GjlmZyWgBMrU8zJ3v2MJlM6++CiB45VKYmhiWWg==",
       "dependencies": {
-        "@octokit/auth-token": "^2.4.0",
-        "@octokit/graphql": "^4.3.1",
-        "@octokit/request": "^5.4.0",
-        "@octokit/types": "^5.0.0",
-        "before-after-hook": "^2.1.0",
-        "universal-user-agent": "^5.0.0"
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.4.12",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/types": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
+      "integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
+      "dependencies": {
+        "@octokit/openapi-types": "^6.0.0"
       }
     },
     "node_modules/@octokit/endpoint": {
@@ -1623,95 +1623,132 @@
         "universal-user-agent": "^6.0.0"
       }
     },
-    "node_modules/@octokit/endpoint/node_modules/universal-user-agent": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
-    },
     "node_modules/@octokit/graphql": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.4.tgz",
-      "integrity": "sha512-ITpZ+dQc0cXAW1FmDkHJJM+8Lb6anUnin0VB5hLBilnYVdLC0ICFU/KIvT7OXfW9S81DE3U4Vx2EypDG1OYaPA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.1.tgz",
+      "integrity": "sha512-2lYlvf4YTDgZCTXTW4+OX+9WTLFtEUc6hGm4qM1nlZjzxj+arizM4aHWzBVBCxY9glh7GIs0WEuiSgbVzv8cmA==",
       "dependencies": {
         "@octokit/request": "^5.3.0",
-        "@octokit/types": "^5.0.0",
+        "@octokit/types": "^6.0.3",
         "universal-user-agent": "^6.0.0"
       }
     },
-    "node_modules/@octokit/graphql/node_modules/universal-user-agent": {
+    "node_modules/@octokit/graphql/node_modules/@octokit/types": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
+      "integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
+      "dependencies": {
+        "@octokit/openapi-types": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-6.0.0.tgz",
+      "integrity": "sha512-CnDdK7ivHkBtJYzWzZm7gEkanA7gKH6a09Eguz7flHw//GacPJLmkHA3f3N++MJmlxD1Fl+mB7B32EEpSCwztQ=="
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.3.0.tgz",
-      "integrity": "sha512-Ye2ZJreP0ZlqJQz8fz+hXvrEAEYK4ay7br1eDpWzr6j76VXs/gKqxFcH8qRzkB3fo/2xh4Vy9VtGii4ZDc9qlA==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.3.tgz",
+      "integrity": "sha512-46lptzM9lTeSmIBt/sVP/FLSTPGx6DCzAdSX3PfeJ3mTf4h9sGC26WpaQzMEq/Z44cOcmx8VsOhO+uEgE3cjYg==",
       "dependencies": {
-        "@octokit/types": "^5.2.0"
+        "@octokit/types": "^6.11.0"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=2"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
+      "integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
+      "dependencies": {
+        "@octokit/openapi-types": "^6.0.0"
       }
     },
     "node_modules/@octokit/plugin-request-log": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz",
-      "integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz",
+      "integrity": "sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ==",
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.17.0.tgz",
-      "integrity": "sha512-NFV3vq7GgoO2TrkyBRUOwflkfTYkFKS0tLAPym7RNpkwLCttqShaEGjthOsPEEL+7LFcYv3mU24+F2yVd3npmg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.0.tgz",
+      "integrity": "sha512-Jc7CLNUueIshXT+HWt6T+M0sySPjF32mSFQAK7UfAg8qGeRI6OM1GSBxDLwbXjkqy2NVdnqCedJcP1nC785JYg==",
       "dependencies": {
-        "@octokit/types": "^4.1.6",
+        "@octokit/types": "^6.13.0",
         "deprecation": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=3"
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-4.1.10.tgz",
-      "integrity": "sha512-/wbFy1cUIE5eICcg0wTKGXMlKSbaAxEr00qaBXzscLXpqhcwgXeS6P8O0pkysBhRfyjkKjJaYrvR1ExMO5eOXQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
+      "integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
       "dependencies": {
-        "@types/node": ">= 8"
+        "@octokit/openapi-types": "^6.0.0"
       }
     },
     "node_modules/@octokit/request": {
-      "version": "5.4.7",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.7.tgz",
-      "integrity": "sha512-FN22xUDP0i0uF38YMbOfx6TotpcENP5W8yJM1e/LieGXn6IoRxDMnBf7tx5RKSW4xuUZ/1P04NFZy5iY3Rax1A==",
+      "version": "5.4.15",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.15.tgz",
+      "integrity": "sha512-6UnZfZzLwNhdLRreOtTkT9n57ZwulCve8q3IT/Z477vThu6snfdkBuhxnChpOKNGxcQ71ow561Qoa6uqLdPtag==",
       "dependencies": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.0.0",
-        "@octokit/types": "^5.0.0",
-        "deprecation": "^2.0.0",
-        "is-plain-object": "^4.0.0",
-        "node-fetch": "^2.3.0",
-        "once": "^1.4.0",
+        "@octokit/types": "^6.7.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
         "universal-user-agent": "^6.0.0"
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
-      "integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.5.tgz",
+      "integrity": "sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==",
       "dependencies": {
-        "@octokit/types": "^5.0.1",
+        "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
       }
     },
-    "node_modules/@octokit/request/node_modules/universal-user-agent": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    "node_modules/@octokit/request-error/node_modules/@octokit/types": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
+      "integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
+      "dependencies": {
+        "@octokit/openapi-types": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/request/node_modules/@octokit/types": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
+      "integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
+      "dependencies": {
+        "@octokit/openapi-types": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/request/node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/@octokit/rest": {
-      "version": "17.11.2",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-17.11.2.tgz",
-      "integrity": "sha512-4jTmn8WossTUaLfNDfXk4fVJgbz5JgZE8eCs4BvIb52lvIH8rpVMD1fgRCrHbSd6LRPE5JFZSfAEtszrOq3ZFQ==",
+      "version": "18.5.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.2.tgz",
+      "integrity": "sha512-Kz03XYfKS0yYdi61BkL9/aJ0pP2A/WK5vF/syhu9/kY30J8He3P68hv9GRpn8bULFx2K0A9MEErn4v3QEdbZcw==",
       "dependencies": {
-        "@octokit/core": "^2.4.3",
-        "@octokit/plugin-paginate-rest": "^2.2.0",
-        "@octokit/plugin-request-log": "^1.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "3.17.0"
+        "@octokit/core": "^3.2.3",
+        "@octokit/plugin-paginate-rest": "^2.6.2",
+        "@octokit/plugin-request-log": "^1.0.2",
+        "@octokit/plugin-rest-endpoint-methods": "5.0.0"
       }
     },
     "node_modules/@octokit/types": {
@@ -1823,6 +1860,55 @@
       },
       "engines": {
         "node": ">=10.18"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/@octokit/core": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.5.4.tgz",
+      "integrity": "sha512-HCp8yKQfTITYK+Nd09MHzAlP1v3Ii/oCohv0/TW9rhSLvzb98BOVs2QmVYuloE6a3l6LsfyGIwb6Pc4ycgWlIQ==",
+      "dependencies": {
+        "@octokit/auth-token": "^2.4.0",
+        "@octokit/graphql": "^4.3.1",
+        "@octokit/request": "^5.4.0",
+        "@octokit/types": "^5.0.0",
+        "before-after-hook": "^2.1.0",
+        "universal-user-agent": "^5.0.0"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.17.0.tgz",
+      "integrity": "sha512-NFV3vq7GgoO2TrkyBRUOwflkfTYkFKS0tLAPym7RNpkwLCttqShaEGjthOsPEEL+7LFcYv3mU24+F2yVd3npmg==",
+      "dependencies": {
+        "@octokit/types": "^4.1.6",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-4.1.10.tgz",
+      "integrity": "sha512-/wbFy1cUIE5eICcg0wTKGXMlKSbaAxEr00qaBXzscLXpqhcwgXeS6P8O0pkysBhRfyjkKjJaYrvR1ExMO5eOXQ==",
+      "dependencies": {
+        "@types/node": ">= 8"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/@octokit/rest": {
+      "version": "17.11.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-17.11.2.tgz",
+      "integrity": "sha512-4jTmn8WossTUaLfNDfXk4fVJgbz5JgZE8eCs4BvIb52lvIH8rpVMD1fgRCrHbSd6LRPE5JFZSfAEtszrOq3ZFQ==",
+      "dependencies": {
+        "@octokit/core": "^2.4.3",
+        "@octokit/plugin-paginate-rest": "^2.2.0",
+        "@octokit/plugin-request-log": "^1.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "3.17.0"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/universal-user-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
+      "integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
+      "dependencies": {
+        "os-name": "^3.1.0"
       }
     },
     "node_modules/@semantic-release/npm": {
@@ -2695,9 +2781,9 @@
       }
     },
     "node_modules/before-after-hook": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
-      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.1.tgz",
+      "integrity": "sha512-/6FKxSTWoJdbsLDF8tdIjaRiFXiE6UHsEHE3OPI/cwPURCVi1ukP0gmLn7XWEiFk5TcwQjjY5PWsU+j+tgXgmw=="
     },
     "node_modules/bn.js": {
       "version": "4.11.9",
@@ -8257,6 +8343,9 @@
       "integrity": "sha512-H/QHeBIN1fIGJX517pvK8IEK53yQOW7YcEI55oYtgjDdoCQQz7eJS94qt5kNrscReEyuD/JcdFCm2XBEcGOITg==",
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-dir": {
@@ -16182,12 +16271,9 @@
       }
     },
     "node_modules/universal-user-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
-      "integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
-      "dependencies": {
-        "os-name": "^3.1.0"
-      }
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
     },
     "node_modules/universalify": {
       "version": "2.0.0",
@@ -16520,6 +16606,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/windows-release/node_modules/cross-spawn": {
@@ -16859,19 +16948,6 @@
         "@octokit/plugin-rest-endpoint-methods": "^4.0.0"
       },
       "dependencies": {
-        "@octokit/core": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.1.2.tgz",
-          "integrity": "sha512-AInOFULmwOa7+NFi9F8DlDkm5qtZVmDQayi7TUgChE3yeIGPq0Y+6cAEXPexQ3Ea+uZy66hKEazR7DJyU+4wfw==",
-          "requires": {
-            "@octokit/auth-token": "^2.4.0",
-            "@octokit/graphql": "^4.3.1",
-            "@octokit/request": "^5.4.0",
-            "@octokit/types": "^5.0.0",
-            "before-after-hook": "^2.1.0",
-            "universal-user-agent": "^6.0.0"
-          }
-        },
         "@octokit/plugin-rest-endpoint-methods": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.1.2.tgz",
@@ -16880,11 +16956,6 @@
             "@octokit/types": "^5.1.1",
             "deprecation": "^2.3.1"
           }
-        },
-        "universal-user-agent": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-          "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
         }
       }
     },
@@ -18169,24 +18240,45 @@
       }
     },
     "@octokit/auth-token": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
-      "integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
+      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
       "requires": {
-        "@octokit/types": "^5.0.0"
+        "@octokit/types": "^6.0.3"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "6.13.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
+          "integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
+          "requires": {
+            "@octokit/openapi-types": "^6.0.0"
+          }
+        }
       }
     },
     "@octokit/core": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.5.4.tgz",
-      "integrity": "sha512-HCp8yKQfTITYK+Nd09MHzAlP1v3Ii/oCohv0/TW9rhSLvzb98BOVs2QmVYuloE6a3l6LsfyGIwb6Pc4ycgWlIQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-6/vlKPP8NF17cgYXqucdshWqmMZGXkuvtcrWCgU5NOI0Pl2GjlmZyWgBMrU8zJ3v2MJlM6++CiB45VKYmhiWWg==",
       "requires": {
-        "@octokit/auth-token": "^2.4.0",
-        "@octokit/graphql": "^4.3.1",
-        "@octokit/request": "^5.4.0",
-        "@octokit/types": "^5.0.0",
-        "before-after-hook": "^2.1.0",
-        "universal-user-agent": "^5.0.0"
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.4.12",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "6.13.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
+          "integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
+          "requires": {
+            "@octokit/openapi-types": "^6.0.0"
+          }
+        }
       }
     },
     "@octokit/endpoint": {
@@ -18197,105 +18289,133 @@
         "@octokit/types": "^5.0.0",
         "is-plain-object": "^4.0.0",
         "universal-user-agent": "^6.0.0"
-      },
-      "dependencies": {
-        "universal-user-agent": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-          "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
-        }
       }
     },
     "@octokit/graphql": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.4.tgz",
-      "integrity": "sha512-ITpZ+dQc0cXAW1FmDkHJJM+8Lb6anUnin0VB5hLBilnYVdLC0ICFU/KIvT7OXfW9S81DE3U4Vx2EypDG1OYaPA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.1.tgz",
+      "integrity": "sha512-2lYlvf4YTDgZCTXTW4+OX+9WTLFtEUc6hGm4qM1nlZjzxj+arizM4aHWzBVBCxY9glh7GIs0WEuiSgbVzv8cmA==",
       "requires": {
         "@octokit/request": "^5.3.0",
-        "@octokit/types": "^5.0.0",
+        "@octokit/types": "^6.0.3",
         "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
-        "universal-user-agent": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-          "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+        "@octokit/types": {
+          "version": "6.13.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
+          "integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
+          "requires": {
+            "@octokit/openapi-types": "^6.0.0"
+          }
         }
       }
     },
+    "@octokit/openapi-types": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-6.0.0.tgz",
+      "integrity": "sha512-CnDdK7ivHkBtJYzWzZm7gEkanA7gKH6a09Eguz7flHw//GacPJLmkHA3f3N++MJmlxD1Fl+mB7B32EEpSCwztQ=="
+    },
     "@octokit/plugin-paginate-rest": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.3.0.tgz",
-      "integrity": "sha512-Ye2ZJreP0ZlqJQz8fz+hXvrEAEYK4ay7br1eDpWzr6j76VXs/gKqxFcH8qRzkB3fo/2xh4Vy9VtGii4ZDc9qlA==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.3.tgz",
+      "integrity": "sha512-46lptzM9lTeSmIBt/sVP/FLSTPGx6DCzAdSX3PfeJ3mTf4h9sGC26WpaQzMEq/Z44cOcmx8VsOhO+uEgE3cjYg==",
       "requires": {
-        "@octokit/types": "^5.2.0"
+        "@octokit/types": "^6.11.0"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "6.13.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
+          "integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
+          "requires": {
+            "@octokit/openapi-types": "^6.0.0"
+          }
+        }
       }
     },
     "@octokit/plugin-request-log": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz",
-      "integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz",
+      "integrity": "sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ==",
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.17.0.tgz",
-      "integrity": "sha512-NFV3vq7GgoO2TrkyBRUOwflkfTYkFKS0tLAPym7RNpkwLCttqShaEGjthOsPEEL+7LFcYv3mU24+F2yVd3npmg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.0.tgz",
+      "integrity": "sha512-Jc7CLNUueIshXT+HWt6T+M0sySPjF32mSFQAK7UfAg8qGeRI6OM1GSBxDLwbXjkqy2NVdnqCedJcP1nC785JYg==",
       "requires": {
-        "@octokit/types": "^4.1.6",
+        "@octokit/types": "^6.13.0",
         "deprecation": "^2.3.1"
       },
       "dependencies": {
         "@octokit/types": {
-          "version": "4.1.10",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-4.1.10.tgz",
-          "integrity": "sha512-/wbFy1cUIE5eICcg0wTKGXMlKSbaAxEr00qaBXzscLXpqhcwgXeS6P8O0pkysBhRfyjkKjJaYrvR1ExMO5eOXQ==",
+          "version": "6.13.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
+          "integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
           "requires": {
-            "@types/node": ">= 8"
+            "@octokit/openapi-types": "^6.0.0"
           }
         }
       }
     },
     "@octokit/request": {
-      "version": "5.4.7",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.7.tgz",
-      "integrity": "sha512-FN22xUDP0i0uF38YMbOfx6TotpcENP5W8yJM1e/LieGXn6IoRxDMnBf7tx5RKSW4xuUZ/1P04NFZy5iY3Rax1A==",
+      "version": "5.4.15",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.15.tgz",
+      "integrity": "sha512-6UnZfZzLwNhdLRreOtTkT9n57ZwulCve8q3IT/Z477vThu6snfdkBuhxnChpOKNGxcQ71ow561Qoa6uqLdPtag==",
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.0.0",
-        "@octokit/types": "^5.0.0",
-        "deprecation": "^2.0.0",
-        "is-plain-object": "^4.0.0",
-        "node-fetch": "^2.3.0",
-        "once": "^1.4.0",
+        "@octokit/types": "^6.7.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
         "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
-        "universal-user-agent": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-          "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+        "@octokit/types": {
+          "version": "6.13.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
+          "integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
+          "requires": {
+            "@octokit/openapi-types": "^6.0.0"
+          }
+        },
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
         }
       }
     },
     "@octokit/request-error": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
-      "integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.5.tgz",
+      "integrity": "sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==",
       "requires": {
-        "@octokit/types": "^5.0.1",
+        "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "6.13.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
+          "integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
+          "requires": {
+            "@octokit/openapi-types": "^6.0.0"
+          }
+        }
       }
     },
     "@octokit/rest": {
-      "version": "17.11.2",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-17.11.2.tgz",
-      "integrity": "sha512-4jTmn8WossTUaLfNDfXk4fVJgbz5JgZE8eCs4BvIb52lvIH8rpVMD1fgRCrHbSd6LRPE5JFZSfAEtszrOq3ZFQ==",
+      "version": "18.5.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.2.tgz",
+      "integrity": "sha512-Kz03XYfKS0yYdi61BkL9/aJ0pP2A/WK5vF/syhu9/kY30J8He3P68hv9GRpn8bULFx2K0A9MEErn4v3QEdbZcw==",
       "requires": {
-        "@octokit/core": "^2.4.3",
-        "@octokit/plugin-paginate-rest": "^2.2.0",
-        "@octokit/plugin-request-log": "^1.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "3.17.0"
+        "@octokit/core": "^3.2.3",
+        "@octokit/plugin-paginate-rest": "^2.6.2",
+        "@octokit/plugin-request-log": "^1.0.2",
+        "@octokit/plugin-rest-endpoint-methods": "5.0.0"
       }
     },
     "@octokit/types": {
@@ -18394,6 +18514,59 @@
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
         "url-join": "^4.0.0"
+      },
+      "dependencies": {
+        "@octokit/core": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.5.4.tgz",
+          "integrity": "sha512-HCp8yKQfTITYK+Nd09MHzAlP1v3Ii/oCohv0/TW9rhSLvzb98BOVs2QmVYuloE6a3l6LsfyGIwb6Pc4ycgWlIQ==",
+          "requires": {
+            "@octokit/auth-token": "^2.4.0",
+            "@octokit/graphql": "^4.3.1",
+            "@octokit/request": "^5.4.0",
+            "@octokit/types": "^5.0.0",
+            "before-after-hook": "^2.1.0",
+            "universal-user-agent": "^5.0.0"
+          }
+        },
+        "@octokit/plugin-rest-endpoint-methods": {
+          "version": "3.17.0",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.17.0.tgz",
+          "integrity": "sha512-NFV3vq7GgoO2TrkyBRUOwflkfTYkFKS0tLAPym7RNpkwLCttqShaEGjthOsPEEL+7LFcYv3mU24+F2yVd3npmg==",
+          "requires": {
+            "@octokit/types": "^4.1.6",
+            "deprecation": "^2.3.1"
+          },
+          "dependencies": {
+            "@octokit/types": {
+              "version": "4.1.10",
+              "resolved": "https://registry.npmjs.org/@octokit/types/-/types-4.1.10.tgz",
+              "integrity": "sha512-/wbFy1cUIE5eICcg0wTKGXMlKSbaAxEr00qaBXzscLXpqhcwgXeS6P8O0pkysBhRfyjkKjJaYrvR1ExMO5eOXQ==",
+              "requires": {
+                "@types/node": ">= 8"
+              }
+            }
+          }
+        },
+        "@octokit/rest": {
+          "version": "17.11.2",
+          "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-17.11.2.tgz",
+          "integrity": "sha512-4jTmn8WossTUaLfNDfXk4fVJgbz5JgZE8eCs4BvIb52lvIH8rpVMD1fgRCrHbSd6LRPE5JFZSfAEtszrOq3ZFQ==",
+          "requires": {
+            "@octokit/core": "^2.4.3",
+            "@octokit/plugin-paginate-rest": "^2.2.0",
+            "@octokit/plugin-request-log": "^1.0.0",
+            "@octokit/plugin-rest-endpoint-methods": "3.17.0"
+          }
+        },
+        "universal-user-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
+          "integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
+          "requires": {
+            "os-name": "^3.1.0"
+          }
+        }
       }
     },
     "@semantic-release/npm": {
@@ -19141,9 +19314,9 @@
       }
     },
     "before-after-hook": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
-      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.1.tgz",
+      "integrity": "sha512-/6FKxSTWoJdbsLDF8tdIjaRiFXiE6UHsEHE3OPI/cwPURCVi1ukP0gmLn7XWEiFk5TcwQjjY5PWsU+j+tgXgmw=="
     },
     "bn.js": {
       "version": "4.11.9",
@@ -29507,12 +29680,9 @@
       }
     },
     "universal-user-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
-      "integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
-      "requires": {
-        "os-name": "^3.1.0"
-      }
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
     },
     "universalify": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "dayjs": "^1.10.4",
         "fs-extra": "^9.1.0",
         "js-yaml": "^4.0.0",
-        "node-libcurl": "^2.3.0",
+        "node-libcurl": "^2.3.2",
         "nodemailer": "^6.4.17",
         "notifme-sdk": "^1.10.0",
         "prettier": "^2.2.1",
@@ -8908,9 +8908,10 @@
       "dev": true
     },
     "node_modules/node-libcurl": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/node-libcurl/-/node-libcurl-2.3.0.tgz",
-      "integrity": "sha512-p3N2bUwvDQxmo9WzKzAGb2UV7HbQ3lIyAK2OyXTIOl3bAojwpMUqYcDnT6yUPUFKejyDixu4wD4SPtxzfTEWpQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/node-libcurl/-/node-libcurl-2.3.2.tgz",
+      "integrity": "sha512-RlKwqxqBwvDOtDxPXRXVkVCVhIVfO8icBj51KiLaChQGuecGGdpzTWa1Byu/C2PhLJntq+lCBA++QO673Uxxmw==",
+      "hasInstallScript": true,
       "dependencies": {
         "env-paths": "2.2.0",
         "nan": "2.14.1",
@@ -24124,9 +24125,9 @@
       "dev": true
     },
     "node-libcurl": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/node-libcurl/-/node-libcurl-2.3.0.tgz",
-      "integrity": "sha512-p3N2bUwvDQxmo9WzKzAGb2UV7HbQ3lIyAK2OyXTIOl3bAojwpMUqYcDnT6yUPUFKejyDixu4wD4SPtxzfTEWpQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/node-libcurl/-/node-libcurl-2.3.2.tgz",
+      "integrity": "sha512-RlKwqxqBwvDOtDxPXRXVkVCVhIVfO8icBj51KiLaChQGuecGGdpzTWa1Byu/C2PhLJntq+lCBA++QO673Uxxmw==",
       "requires": {
         "env-paths": "2.2.0",
         "nan": "2.14.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@actions/core": "^1.2.6",
     "@actions/github": "^4.0.0",
     "@koj/config": "^1.2.11",
+    "@octokit/rest": "^18.5.2",
     "@sindresorhus/slugify": "^1.1.0",
     "axios": "^0.21.1",
     "dayjs": "^1.10.4",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "dayjs": "^1.10.4",
     "fs-extra": "^9.1.0",
     "js-yaml": "^4.0.0",
-    "node-libcurl": "^2.3.0",
+    "node-libcurl": "^2.3.2",
     "nodemailer": "^6.4.17",
     "notifme-sdk": "^1.10.0",
     "prettier": "^2.2.1",


### PR DESCRIPTION
Solution is to bump [@octokit/rest](https://github.com/octokit/rest.js) dependency.

Also had to update `node-libcurl`.

Fixes upptime/upptime#288
Fixes upptime/upptime#296

Tested here : https://github.com/betagouv/api-particulier-status/runs/2351594726?check_suite_focus=true
