### PR TITLE
Updating `actions/checkout` to version `v2.4.0`.

### DIFF
--- a/src/helpers/workflows.ts
+++ b/src/helpers/workflows.ts
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2.4.0
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT }}
@@ -84,7 +84,7 @@ jobs:
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2.4.0
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT }}
@@ -119,7 +119,7 @@ jobs:
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2.4.0
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT }}
@@ -186,7 +186,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2.4.0
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT }}
@@ -227,7 +227,7 @@ jobs:
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2.4.0
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT }}
@@ -267,7 +267,7 @@ jobs:
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2.4.0
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT }}
@@ -299,7 +299,7 @@ jobs:
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2.4.0
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT }}
@@ -329,7 +329,7 @@ jobs:
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2.4.0
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT }}

--- a/src/workflows/graphs.yml
+++ b/src/workflows/graphs.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT }}

--- a/src/workflows/response-time.yml
+++ b/src/workflows/response-time.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT }}

--- a/src/workflows/setup.yml
+++ b/src/workflows/setup.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT }}

--- a/src/workflows/site.yml
+++ b/src/workflows/site.yml
@@ -19,7 +19,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT }}

--- a/src/workflows/summary.yml
+++ b/src/workflows/summary.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT }}

--- a/src/workflows/update-template.yml
+++ b/src/workflows/update-template.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT }}

--- a/src/workflows/updates.yml
+++ b/src/workflows/updates.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT }}

--- a/src/workflows/uptime.yml
+++ b/src/workflows/uptime.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
Updating `actions/checkout` to version `v2.4.0`.

@AnandChowdhary - I am not sure if this needs to be updated in other places; I do not claim to be a JS expert at all, so I might be missing some steps (I saw some references to `v2.3.3` in the `dist/` directory? Not sure if that is produced as a side effect of some CI build?)