### PR TITLE
Add custom tags to issues created by uptime-monitor

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -11,6 +11,7 @@ export interface UpptimeConfig {
     expectedStatusCodes?: number[];
     assignees?: string[];
     headers?: string[];
+    tags?: string[];
     slug?: string;
     body?: string;
     icon?: string;

--- a/src/update.ts
+++ b/src/update.ts
@@ -344,7 +344,7 @@ generator: Upptime <https://github.com/upptime/upptime>
 - HTTP code: ${result.httpCode}
 - Response time: ${responseTime} ms
 `,
-                labels: ["status", slug],
+                labels: ["status", slug, ...site.tags || []],
               });
               const assignees = [...(config.assignees || []), ...(site.assignees || [])];
               await octokit.issues.addAssignees({


### PR DESCRIPTION
Ref https://github.com/upptime/upptime/discussions/527

Adds tags property to sites and sets the tags as labels on new issues. Makes it possible to mark downtime issues with for instance "test" or "prod"