### PR TITLE
Changed favicon api

### DIFF
--- a/src/summary.ts
+++ b/src/summary.ts
@@ -48,7 +48,7 @@ export const generateSummary = async () => {
 
     let fallbackIcon = "";
     try {
-      fallbackIcon = `https://favicons.githubusercontent.com/${parse(site.url).hostname}`;
+      fallbackIcon = `https://icons.duckduckgo.com/ip3/${parse(site.url).hostname}.ico`;
     } catch (error) {}
 
     pageStatuses.push({


### PR DESCRIPTION
_Fixes https://github.com/upptime/upptime/discussions/552_
Switched to DuckDuckGo favicon API, because GitHub favicon API is no longer in operation.