### PR TITLE
Unlock issues while working with them so Upptime+GITHUB_TOKEN can close issues it creates

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -70,11 +70,21 @@ export const update = async (shouldCommit = false) => {
           .filter((i) => i.length);
 
       if (dayjs(metadata.end).isBefore(dayjs())) {
+        await octokit.issues.unlock({
+          owner,
+          repo,
+          issue_number: incident.number,
+        });
         await octokit.issues.update({
           owner,
           repo,
           issue_number: incident.number,
           state: "closed",
+        });
+        await octokit.issues.lock({
+          owner,
+          repo,
+          issue_number: incident.number,
         });
         console.log("Closed maintenance completed event", incident.number);
       } else
@@ -387,6 +397,11 @@ generator: Upptime <https://github.com/upptime/upptime>
             }
           } else if (issues.data.length) {
             // If the site just came back up
+            await octokit.issues.unlock({
+              owner,
+              repo,
+              issue_number: issues.data[0].number,
+            });
             await octokit.issues.createComment({
               owner,
               repo,
@@ -405,6 +420,11 @@ generator: Upptime <https://github.com/upptime/upptime>
               repo,
               issue_number: issues.data[0].number,
               state: "closed",
+            });
+            await octokit.issues.lock({
+              owner,
+              repo,
+              issue_number: issues.data[0].number,
             });
             console.log("Closed issue");
             try {


### PR DESCRIPTION
When using Upptime with a `GITHUB_TOKEN` _(because a PAT is scary - see https://github.com/upptime/upptime/discussions/231)_, Upptime logs errors and fails when trying to automatically close an issue. This is because github actions are not allowed to work with locked issues. 

Oddly though, they Github Actions can lock/unlock issues, so this change enables that workaround. See https://github.com/orgs/community/discussions/25230#discussioncomment-3246970

Here's the problem I hit -- my company's website had a false positive - Upptime [opened an issue on Cycle 1](https://github.com/quickcode-ai/quickcode-status/runs/8246248036?check_suite_focus=true#step:3:27), then went to [close it 5m later on Cycle 2, but failed.](https://github.com/quickcode-ai/quickcode-status/runs/8246420766?check_suite_focus=true#step:3:22)

![image](https://user-images.githubusercontent.com/3299155/189139843-94b33d55-5084-4a02-b164-a3e6ea44cd3d.png)


