### PR TITLE
Ability to hide sources in discord notifications

### DIFF
--- a/src/helpers/notifications.ts
+++ b/src/helpers/notifications.ts
@@ -30,7 +30,13 @@ export const sendNotification = async (config: UpptimeConfig, text: string) => {
     } else if (notification.type === "discord") {
       console.log("[debug] Sending Discord notification");
       const webhookUrl = getSecret("DISCORD_WEBHOOK_URL");
-      if (webhookUrl) await axios.post(webhookUrl, { content: text });
+      if (webhookUrl) {
+        if (webhookUrl.indexOf("?hideUpptimeSource")) {
+            // replace the first line (which is the source), but leave the second link (the github issue) intact
+            text = l.replace(/(?:https?):\/\/[\n\S]+/, '(redacted)');
+        }
+        await axios_1.default.post(webhookUrl, { content: text });
+      }
     } else if (notification.type === "email") {
       console.log("[debug] Sending email notification");
       const transporter = nodemailer.createTransport({


### PR DESCRIPTION
This pull request implements a hacky workaround for issues like https://github.com/upptime/upptime/issues/597, where public facing channels (such as discord) could leak endpoints or raw server addresses.

add `?hideUpptimeSource` to the end of the discord webhook secret, and it'll redact the first url.

This currently only covers the Discord notification type, and would probably benefit from a clean configuration option.

I'd love to hear back in what form you'd like to see this feature be implemented, but hope that this could at least suffice for now.