### PR TITLE
Allow verbose logging in libcurl

### DIFF
--- a/src/helpers/request.ts
+++ b/src/helpers/request.ts
@@ -25,7 +25,13 @@ export const curl = (
     curl.setOpt("CONNECTTIMEOUT", 10);
     curl.setOpt("TIMEOUT", 30);
     curl.setOpt("HEADER", 1);
-    curl.setOpt("VERBOSE", false);
+
+    if(site.verbose) {
+      curl.setOpt("VERBOSE", true);
+    } else {
+      curl.setOpt("VERBOSE", false);
+    }
+
     curl.setOpt("CUSTOMREQUEST", method);
     curl.on("error", (error) => {
       curl.close();

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -17,6 +17,7 @@ export interface UpptimeConfig {
     icon?: string;
     maxResponseTime?: number;
     maxRedirects?: number;
+    verbose?: boolean;
     __dangerous__insecure?: boolean;
     __dangerous__disable_verify_peer?: boolean;
     __dangerous__disable_verify_host?: boolean;


### PR DESCRIPTION
Currently the verbose option in `libcurl` is forced to `false`.

I am currently getting timeouts from my uptime checks but the only error I see is `Got an error (on error) [Error: Timeout was reached]`. [You can see the log in my action here.](https://github.com/AceCentre/upptime/actions/runs/3405937283/jobs/5664272649#step:3:22)

I want to know more about what is happening in `libcurl` so I can figure out what is causing the error. However, I can't see into whats going on inside `libcurl` because the logging is forced off.

This PR allows you to turn on verbose logging per site.