### PR TITLE
⬆️ Upgrade actions/checkout

### DIFF
--- a/src/helpers/workflows.ts
+++ b/src/helpers/workflows.ts
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT }}
@@ -84,7 +84,7 @@ jobs:
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT }}
@@ -119,7 +119,7 @@ jobs:
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT }}
@@ -186,7 +186,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT }}
@@ -227,7 +227,7 @@ jobs:
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT }}
@@ -259,7 +259,7 @@ jobs:
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT }}
@@ -291,7 +291,7 @@ jobs:
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT }}
@@ -321,7 +321,7 @@ jobs:
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT }}


### PR DESCRIPTION
When i use upptime, i get this:

<img width="1534" alt="image" src="https://user-images.githubusercontent.com/25154432/201492769-079da3b9-54e5-45a0-990e-293b44f04646.png">

```bash
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2.3.3, upptime/uptime-monitor@v1.28.0
```

I found it caused by [actions/checkout](https://github.com/actions/checkout).

Now, it had upgraded to `v3` to use `node16`.

<img width="850" alt="image" src="https://user-images.githubusercontent.com/25154432/201492813-41d87711-c89f-4918-ab83-7abb9fdfef0e.png">

Let's upgrade it!