### PR TITLE
⬆️  fix deprecation warning for Node.js 12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: "Command to run"
     default: "update"
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   icon: "chevron-up"


### PR DESCRIPTION
   Node.js 12 actions are deprecated.
   For more information see:
   https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
   Please update the following actions to use Node.js 16: upptime/uptime-monitor@v1.29.0