### PR TITLE
Fix typos

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -387,7 +387,7 @@ generator: Upptime <https://github.com/upptime/upptime>
                 await sendNotification(
                   status === "down"
                     ? `${downmsg.replace("$STATUS", "**down**").replace("$EMOJI", `${config.commitPrefixStatusDown || "🟥"}`)}`
-                    : `${downmsg.replace("$STATUS", "experiencing **degrading performance**").replace("$EMOJI", `${config.commitPrefixStatusDegraded || "🟥"}`)}`
+                    : `${downmsg.replace("$STATUS", "experiencing **degraded performance**").replace("$EMOJI", `${config.commitPrefixStatusDegraded || "🟨"}`)}`
                 );
               } catch (error) {
                 console.log(error);


### PR DESCRIPTION
"Degraded" notification had the incorrect emoji; red square instead of amber square. Also fixed grammar; "[site] is experiencing degrad**ed**" is more grammatically correct than degrad**ing** performance