### PR TITLE
Use slugify if site has no slug

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -116,7 +116,7 @@ export const update = async (shouldCommit = false) => {
       currentStatus = siteHistory.status || "unknown";
       startTime = new Date(siteHistory.startTime || new Date());
     } catch (error) { }
-    console.log("Current status", site.slug, currentStatus, startTime);
+    console.log("Current status", site.slug || slugify(site.name), currentStatus, startTime);
 
     /**
      * Check whether the site is online


### PR DESCRIPTION
This "fixes" the following line on Uptime CI checks:
```
Checking https://DOMAIN
Current status undefined up 2023-06-04T14:49:10.000Z
Result from test 200 0.982486
```

This can also been seen on the upptime repos action runs:
https://github.com/upptime/upptime/actions/runs/5171412631/jobs/9314941347#step:3:14