### PR TITLE
Make npm installs quieter and faster

### DIFF
--- a/src/site.ts
+++ b/src/site.ts
@@ -32,9 +32,9 @@ export const generateSite = async () => {
   }
   exec("npm init -y");
   config.repo;
-  exec(`npm i ${sitePackage} --no-audit --no-fund`);
+  exec(`npm i ${sitePackage} --no-audit --no-fund --loglevel=error`);
   cp("-r", `node_modules/${sitePackage}/*`, ".");
-  exec("npm i --no-audit --no-fund");
+  exec("npm i --no-audit --no-fund --loglevel=error");
   exec("npm run export");
   mkdir("-p", "status-page/__sapper__/export");
   cp("-r", "__sapper__/export/*", "status-page/__sapper__/export");

--- a/src/site.ts
+++ b/src/site.ts
@@ -32,9 +32,9 @@ export const generateSite = async () => {
   }
   exec("npm init -y");
   config.repo;
-  exec(`npm i ${sitePackage}`);
+  exec(`npm i ${sitePackage} --no-audit --no-fund`);
   cp("-r", `node_modules/${sitePackage}/*`, ".");
-  exec("npm i");
+  exec("npm i --no-audit --no-fund");
   exec("npm run export");
   mkdir("-p", "status-page/__sapper__/export");
   cp("-r", "__sapper__/export/*", "status-page/__sapper__/export");


### PR DESCRIPTION
By ignoring auditing, funding, and warning messages the action output becomes more succinct and slightly faster. Here's the current output, with the lines that will be removed:

```diff
added 51 packages, and audited 52 packages in 3s

-found 0 vulnerabilities
-npm WARN deprecated sourcemap-codec@1.4.8: Please use @jridgewell/sourcemap-codec instead
-npm WARN deprecated rollup-plugin-terser@7.0.2: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser
-npm WARN deprecated sapper@0.29.3: SvelteKit is the successor to Sapper - https://kit.svelte.dev/

added 1087 packages, removed 1 package, and audited 1605 packages in 44s

-129 packages are looking for funding
-  run `npm fund` for details

-86 vulnerabilities ([76](https://github.com/lowlydba/carson-living-upptime/actions/runs/5431812853/jobs/9878421049#step:7:77) moderate, 8 high, 2 critical)

-To address issues that do not require attention, run:
-  npm audit fix

-To address all issues possible (including breaking changes), run:
-  npm audit fix --force

-Some issues need review, and may require choosing
-a different dependency.

-Run `npm audit` for details.
```