### PR TITLE
Adding time delta to the 'resolved' comment 

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -19,6 +19,26 @@ import { generateSummary } from "./summary";
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+function getHumanReadableTimeDifference(startTime) {
+  const now = new Date();
+  const deltaMilliseconds = now - startTime;
+  const seconds = Math.floor(deltaMilliseconds / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) {
+    return `${days} days, ${hours % 24} hours, ${minutes % 60} minutes`;
+  } else if (hours > 0) {
+    return `${hours} hours, ${minutes % 60} minutes`;
+  } else if (minutes > 0) {
+    return `${minutes} minutes`;
+  } else {
+    return `${seconds} seconds`;
+  }
+}
+
+
 export const update = async (shouldCommit = false) => {
   if (!(await shouldContinue())) return;
   await mkdirp("history");
@@ -402,17 +422,20 @@ generator: Upptime <https://github.com/upptime/upptime>
               repo,
               issue_number: issues.data[0].number,
             });
-            await octokit.issues.createComment({
+           await octokit.issues.createComment({
               owner,
               repo,
               issue_number: issues.data[0].number,
-              body: `**Resolved:** ${site.name} ${issues.data[0].title.includes("degraded")
+              body: `**Resolved:** ${site.name} ${
+                issues.data[0].title.includes("degraded")
                   ? "performance has improved"
                   : "is back up"
-                } in [\`${lastCommitSha.substr(
-                  0,
-                  7
-                )}\`](https://github.com/${owner}/${repo}/commit/${lastCommitSha}).`,
+              } in [\`${lastCommitSha.substr(
+                0,
+                7
+              )}\`](https://github.com/${owner}/${repo}/commit/${lastCommitSha}).\n\nTime taken: ${getHumanReadableTimeDifference(
+                startTime
+              )}.`,
             });
             console.log("Created comment in issue");
             await octokit.issues.update({

--- a/src/update.ts
+++ b/src/update.ts
@@ -433,7 +433,7 @@ generator: Upptime <https://github.com/upptime/upptime>
               } in [\`${lastCommitSha.substr(
                 0,
                 7
-              )}\`](https://github.com/${owner}/${repo}/commit/${lastCommitSha}).\n\nTime taken: ${getHumanReadableTimeDifference(
+              )}\`](https://github.com/${owner}/${repo}/commit/${lastCommitSha}) after ${getHumanReadableTimeDifference(
                 startTime
               )}.`,
             });

--- a/src/update.ts
+++ b/src/update.ts
@@ -27,6 +27,7 @@ function getHumanReadableTimeDifference(startTime) {
   const hours = Math.floor(minutes / 60);
   const days = Math.floor(hours / 24);
 
+  
   if (days > 0) {
     return `${days} days, ${hours % 24} hours, ${minutes % 60} minutes`;
   } else if (hours > 0) {

--- a/src/update.ts
+++ b/src/update.ts
@@ -27,7 +27,6 @@ function getHumanReadableTimeDifference(startTime) {
   const hours = Math.floor(minutes / 60);
   const days = Math.floor(hours / 24);
 
-  
   if (days > 0) {
     return `${days} days, ${hours % 24} hours, ${minutes % 60} minutes`;
   } else if (hours > 0) {


### PR DESCRIPTION
Hi, 

**What does it do:**
After having a few downtime incidents I wondered how long it took for the downtime to resolve itself.  Thats why I figured to add the duration of the incident to the comment that Upptime posts once a website comes back online. 

I did it quite hacky but that is mainly because I could not find where functions go in the repo. Please let me know if: 
- You'd like to have that feature added then I'll clean it up, and make sure to test properly
- Where you'd like these kind of generic helper functions (finding a timedelta between 2 timestamps) 
