### PR TITLE
Fixed broken links to contribution guidelines and code of conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains Upptime's GitHub Action.
 
 ## 🎁 Contributing
 
-This repository is for Upptime's GitHub Action. We love contributions, so please read our [Contributing Guidelines](https://github.com/upptime-js/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/upptime-js/.github/blob/master/CODE_OF_CONDUCT.md) and open an issue or make a pull request!
+This repository is for Upptime's GitHub Action. We love contributions, so please read our [Contributing Guidelines](https://github.com/upptime/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/upptime/.github/blob/main/CODE_OF_CONDUCT.md) and open an issue or make a pull request!
 
 ### Issues
 


### PR DESCRIPTION
When working on something else I found the contribution guidelines and code of conduct had broken links. I fixed that. No code was changed. The other pull request I made for this can be disregarded. I added some code changes because I was not paying attention. 

Have a great day! 