### PR TITLE
Add Google Chat Notifications Webhook Support

### DIFF
--- a/src/helpers/notifications.ts
+++ b/src/helpers/notifications.ts
@@ -27,6 +27,10 @@ export const sendNotification = async (config: UpptimeConfig, text: string) => {
           { channel: notification.channel, text },
           { headers: { Authorization: `Bearer ${getSecret("SLACK_BOT_ACCESS_TOKEN")}` } }
         );
+    } else if (notification.type === "googlechat") {
+      console.log("[debug] Sending Google Chat notification");
+      const webhookUrl = getSecret("GOOGLE_CHAT_WEBHOOK_URL");
+      if (webhookUrl) await axios.post(webhookUrl, { "text": text });
     } else if (notification.type === "discord") {
       console.log("[debug] Sending Discord notification");
       const webhookUrl = getSecret("DISCORD_WEBHOOK_URL");

--- a/src/helpers/notifme.ts
+++ b/src/helpers/notifme.ts
@@ -226,6 +226,18 @@ export const sendNotification = async (message: string) => {
     }
     console.log("Finished sending Discord");
   }
+  if (getSecret("NOTIFICATION_GOOGLE_CHAT_WEBHOOK_URL")) {
+    console.log("Sending Google Chat");
+    try {
+      await axios.post(getSecret("NOTIFICATION_GOOGLE_CHAT_WEBHOOK_URL") as string, {
+        text: message,
+      });
+      console.log("Success Google Chat");
+    } catch (error) {
+      console.log("Got an error", error);
+    }
+    console.log("Finished sending Google Chat");
+  }
   if (
     getSecret("NOTIFICATION_ZULIP_MESSAGE_URL") &&
     getSecret("NOTIFICATION_ZULIP_API_EMAIL") &&


### PR DESCRIPTION
Google Chat supports [webhooks](https://developers.google.com/chat/how-tos/webhooks) in their Spaces group chat option. The structure is a flat JSON payload:

```json
{
  "text": "message"
}
```

This PR adds the option in a very similar style to the existing Discord notifications.