### PR TITLE
Add branches to setupCI workflow file

### DIFF
--- a/src/helpers/workflows.ts
+++ b/src/helpers/workflows.ts
@@ -112,6 +112,9 @@ on:
   push:
     paths:
       - ".upptimerc.yml"
+    branches:
+      - "master"
+      - "main"
   repository_dispatch:
     types: [setup]
   workflow_dispatch:


### PR DESCRIPTION
This should prevent issues where modifying the config file on a separate branch causes the Setup CI workflow to run, causing extra commits that aren't needed.