### PR TITLE
👷 use latest major version for actions/setup-node

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           token: ${{ secrets.GH_PAT }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
           cache: 'npm'

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
           cache: 'npm'

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -12,7 +12,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           token: ${{ secrets.GH_PAT }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
           cache: 'npm'

--- a/dist/helpers/workflows.js
+++ b/dist/helpers/workflows.js
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${config.runner || constants_1.DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT || github.token }}
@@ -75,7 +75,7 @@ jobs:
     runs-on: ${config.runner || constants_1.DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT || github.token }}
@@ -110,7 +110,7 @@ jobs:
     runs-on: ${config.runner || constants_1.DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT || github.token }}
@@ -176,7 +176,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT || github.token }}
@@ -215,7 +215,7 @@ jobs:
     runs-on: ${config.runner || constants_1.DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT || github.token }}
@@ -246,7 +246,7 @@ jobs:
     runs-on: ${config.runner || constants_1.DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT || github.token }}
@@ -277,7 +277,7 @@ jobs:
     runs-on: ${config.runner || constants_1.DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT || github.token }}
@@ -306,7 +306,7 @@ jobs:
     runs-on: ${config.runner || constants_1.DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT || github.token }}

--- a/src/helpers/workflows.ts
+++ b/src/helpers/workflows.ts
@@ -53,7 +53,7 @@ jobs:
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT || github.token }}
@@ -85,7 +85,7 @@ jobs:
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT || github.token }}
@@ -121,7 +121,7 @@ jobs:
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT || github.token }}
@@ -190,7 +190,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT || github.token }}
@@ -232,7 +232,7 @@ jobs:
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT || github.token }}
@@ -264,7 +264,7 @@ jobs:
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT || github.token }}
@@ -296,7 +296,7 @@ jobs:
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT || github.token }}
@@ -326,7 +326,7 @@ jobs:
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: \${{ github.head_ref }}
           token: \${{ secrets.GH_PAT || github.token }}


### PR DESCRIPTION
Use latest major version of [actions/setup-node](https://github.com/actions/setup-node) for GitHub Actions