### PR TITLE
Fix priority issue of status check

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -275,26 +275,29 @@ export const update = async (shouldCommit = false) => {
         )
           ? "up"
           : "down";
-        if (parseInt(responseTime) > (site.maxResponseTime || 60000)) status = "degraded";
-        if (status === "up" && typeof result.data === "string") {
-          if (site.__dangerous__body_down && result.data.includes(replaceEnvironmentVariables(site.__dangerous__body_down)))
+        if (status === "up") {
+          let is_down = site.__dangerous__body_down &&
+            result.data.includes(replaceEnvironmentVariables(site.__dangerous__body_down));
+          is_down = is_down || (
+            site.__dangerous__body_down_if_text_missing &&
+            !result.data.includes(replaceEnvironmentVariables(site.__dangerous__body_down_if_text_missing))
+          );
+          if (is_down)
             status = "down";
-          if (
-            site.__dangerous__body_degraded &&
-            result.data.includes(replaceEnvironmentVariables(site.__dangerous__body_degraded))
-          )
-            status = "degraded";
+          else {
+            let is_degraded = site.__dangerous__body_degraded &&
+              result.data.includes(replaceEnvironmentVariables(site.__dangerous__body_degraded));
+            is_degraded = is_degraded || (
+              site.__dangerous__body_degraded_if_text_missing &&
+              !result.data.includes(replaceEnvironmentVariables(site.__dangerous__body_degraded_if_text_missing))
+            );
+            is_degraded = is_degraded || (
+              parseInt(responseTime) > (site.maxResponseTime || 60000)
+            );
+            if (is_degraded)
+              status = "degraded";
+          }
         }
-        if (
-          site.__dangerous__body_degraded_if_text_missing &&
-          !result.data.includes(replaceEnvironmentVariables(site.__dangerous__body_degraded_if_text_missing))
-        )
-          status = "degraded";
-        if (
-          site.__dangerous__body_down_if_text_missing &&
-          !result.data.includes(replaceEnvironmentVariables(site.__dangerous__body_down_if_text_missing))
-        )
-          status = "down";
         return { result, responseTime, status };
       }
     };


### PR DESCRIPTION
This is an attempt to fix https://github.com/upptime/upptime/issues/881

I see that the type check for `result.data` is already done [here](https://github.com/upptime/uptime-monitor/blob/a2ff879ffd0ace540d1b14122b65366f0ac36e1c/src/helpers/request.ts#L42), so `typeof result.data === "string"` is removed. Let me know to add it back if it is not the case.