### PR TITLE
Make number of attempts configurable (default is 5)

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -19,6 +19,7 @@ export interface UpptimeConfig {
     maxRedirects?: number;
     verbose?: boolean;
     ipv6?: boolean;
+    attempts?: number;
     __dangerous__insecure?: boolean;
     __dangerous__disable_verify_peer?: boolean;
     __dangerous__disable_verify_host?: boolean;

--- a/src/update.ts
+++ b/src/update.ts
@@ -173,7 +173,7 @@ export const update = async (shouldCommit = false) => {
 
           const tcpResult = await ping({
             address,
-            attempts: 5,
+            attempts: site.attempts || 5,
             port: Number(replaceEnvironmentVariables(site.port ? String(site.port) : "")),
           });
           if (


### PR DESCRIPTION
In our case a service does experience periods of 503 which we are ok with ATM. I would like to increase number of attempts for it.  And ideally add some waiting/sleep between them (not implemented here - do not know codebase enough yet)

TODOs?
- [ ] get guidance on if/how to add sleep between attempts
- [ ] anything to do about src/helpers/workflows.ts ?  I saw that for ipv6 option there were some related code there
- [ ] pair with documentation PR for https://github.com/upptime/upptime.js.org ?

Please advise