### PR TITLE
feat: Add custom webhook as notification option

### DIFF
--- a/src/helpers/notifme.ts
+++ b/src/helpers/notifme.ts
@@ -1,6 +1,6 @@
-import NotifmeSdk, { EmailProvider, SlackProvider, SmsProvider } from "notifme-sdk";
 import axios from "axios";
 import type { Channel } from "notifme-sdk";
+import NotifmeSdk, { EmailProvider, SlackProvider, SmsProvider } from "notifme-sdk";
 import { replaceEnvironmentVariables } from "./environment";
 import { getSecret } from "./secrets";
 
@@ -390,5 +390,24 @@ export const sendNotification = async (message: string) => {
       console.log("Got an error", error);
     }
     console.log("Finished sending Microsoft Teams");
+  }
+  if (getSecret("NOTIFICATION_WEBHOOK")) {
+    console.log("Sending Webhook");
+    try {
+      await axios.post(`${getSecret("NOTIFICATION_WEBHOOK_URL")}`,{
+        data: {
+          message: JSON.stringify(message),
+      }
+      },
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+      console.log("Success Webhook");
+    } catch (error) {
+      console.log("Got an error", error);
+    }
+    console.log("Finished sending Webhook");
   }
 };

--- a/src/helpers/notifme.ts
+++ b/src/helpers/notifme.ts
@@ -394,7 +394,7 @@ export const sendNotification = async (message: string) => {
   if (getSecret("NOTIFICATION_CUSTOM_WEBHOOK")) {
     console.log("Sending Webhook");
     try {
-      await axios.post(`${getSecret("NOTIFICATION_WEBHOOK_URL")}`,{
+      await axios.post(`${getSecret("NOTIFICATION_CUSTOM_WEBHOOK_URL")}`,{
         data: {
           message: JSON.stringify(message),
       }

--- a/src/helpers/notifme.ts
+++ b/src/helpers/notifme.ts
@@ -391,7 +391,7 @@ export const sendNotification = async (message: string) => {
     }
     console.log("Finished sending Microsoft Teams");
   }
-  if (getSecret("NOTIFICATION_WEBHOOK")) {
+  if (getSecret("NOTIFICATION_CUSTOM_WEBHOOK")) {
     console.log("Sending Webhook");
     try {
       await axios.post(`${getSecret("NOTIFICATION_WEBHOOK_URL")}`,{


### PR DESCRIPTION
Add the support of custom webhooks as notification endpoint

This would be the first step to solve [upptime discussions 191](https://github.com/orgs/upptime/discussions/191)

It uses `NOTIFICATION_WEBHOOK` boolean and
`NOTIFICATION_WEBHOOK_URL` for the URL

Other configuration could be possible when this PR gets merged.

Thanks ✌️ 