### PR TITLE
Introduce new check method ("SSL")

### DIFF
--- a/src/helpers/check-tls.spec.ts
+++ b/src/helpers/check-tls.spec.ts
@@ -1,44 +1,43 @@
-import { checkTls } from "./check-tls"
+import { checkTls } from "./check-tls";
 
 test("checkTls", async () => {
-    const tcpResult = await checkTls({
-        address: "smtp.gmail.com",
-        port: 465
-    })
-    expect(tcpResult.results.every(
-        (result) => Object.prototype.toString.call((result as any).err) === "[object Error]"
-    )).toBe(false)
-    expect(tcpResult.avg || -1).toBeGreaterThan(0)
-    expect(tcpResult.avg || 0).toBeLessThan(60000)
-})
+  const tcpResult = await checkTls({
+    address: "smtp.gmail.com",
+    port: 465,
+  });
+  expect(tcpResult.results.every(
+    (result) => Object.prototype.toString.call((result as any).err) === "[object Error]"
+  )).toBe(false);
+  expect(tcpResult.avg || -1).toBeGreaterThan(0);
+  expect(tcpResult.avg || 0).toBeLessThan(60000);
+});
 
 test("checkTls2", async () => {
-    const tcpResult = await checkTls({
-        address: "wrong.host.badssl.com",
-    })
-    console.log(tcpResult)
-    expect(tcpResult.results.every(
-        (result) => Object.prototype.toString.call((result as any).err) === "[object Error]"
-    )).toBe(true)
-    expect(tcpResult.avg).toBe(0)
-})
+  const tcpResult = await checkTls({
+    address: "wrong.host.badssl.com",
+  });
+  expect(tcpResult.results.every(
+    (result) => Object.prototype.toString.call((result as any).err) === "[object Error]"
+  )).toBe(true);
+  expect(tcpResult.avg).toBe(0);
+});
 
 test("checkTls3", async () => {
-    const tcpResult = await checkTls({
-        address: "expired.host.badssl.com",
-    })
-    expect(tcpResult.results.every(
-        (result) => Object.prototype.toString.call((result as any).err) === "[object Error]"
-    )).toBe(true)
-    expect(tcpResult.avg).toBe(0)
-})
+  const tcpResult = await checkTls({
+    address: "expired.host.badssl.com",
+  });
+  expect(tcpResult.results.every(
+    (result) => Object.prototype.toString.call((result as any).err) === "[object Error]"
+  )).toBe(true);
+  expect(tcpResult.avg).toBe(0);
+});
 
 test("checkTls4", async () => {
-    const tcpResult = await checkTls({
-        address: "self-signed.badssl.com",
-    })
-    expect(tcpResult.results.every(
-        (result) => Object.prototype.toString.call((result as any).err) === "[object Error]"
-    )).toBe(true)
-    expect(tcpResult.avg).toBe(0)
-})
+  const tcpResult = await checkTls({
+    address: "self-signed.badssl.com",
+  });
+  expect(tcpResult.results.every(
+    (result) => Object.prototype.toString.call((result as any).err) === "[object Error]"
+  )).toBe(true);
+  expect(tcpResult.avg).toBe(0);
+});

--- a/src/helpers/check-tls.spec.ts
+++ b/src/helpers/check-tls.spec.ts
@@ -1,0 +1,44 @@
+import { checkTls } from "./check-tls"
+
+test("checkTls", async () => {
+    const tcpResult = await checkTls({
+        address: "smtp.gmail.com",
+        port: 465
+    })
+    expect(tcpResult.results.every(
+        (result) => Object.prototype.toString.call((result as any).err) === "[object Error]"
+    )).toBe(false)
+    expect(tcpResult.avg || -1).toBeGreaterThan(0)
+    expect(tcpResult.avg || 0).toBeLessThan(60000)
+})
+
+test("checkTls2", async () => {
+    const tcpResult = await checkTls({
+        address: "wrong.host.badssl.com",
+    })
+    console.log(tcpResult)
+    expect(tcpResult.results.every(
+        (result) => Object.prototype.toString.call((result as any).err) === "[object Error]"
+    )).toBe(true)
+    expect(tcpResult.avg).toBe(0)
+})
+
+test("checkTls3", async () => {
+    const tcpResult = await checkTls({
+        address: "expired.host.badssl.com",
+    })
+    expect(tcpResult.results.every(
+        (result) => Object.prototype.toString.call((result as any).err) === "[object Error]"
+    )).toBe(true)
+    expect(tcpResult.avg).toBe(0)
+})
+
+test("checkTls4", async () => {
+    const tcpResult = await checkTls({
+        address: "self-signed.badssl.com",
+    })
+    expect(tcpResult.results.every(
+        (result) => Object.prototype.toString.call((result as any).err) === "[object Error]"
+    )).toBe(true)
+    expect(tcpResult.avg).toBe(0)
+})

--- a/src/helpers/check-tls.ts
+++ b/src/helpers/check-tls.ts
@@ -1,0 +1,65 @@
+import { connect } from "tls";
+import { Options, Results, Result } from "tcp-ping";
+
+export const checkTls = (options: Options) => new Promise<Result>((resolve, reject) => {
+    let i = 0;
+    const results: Results[] = [];
+    const check = () => {
+        if (i < (options.attempts || 10)) {
+            doConnect();
+        } else {
+            resolve({
+                address: options.address || "localhost",
+                port: options.port || 443,
+                attempts: options.attempts || 10,
+                avg: results.reduce((acc, curr) => acc + (curr.time || 0), 0) / results.length,
+                max: results.reduce((acc, curr) => Math.max(acc, curr.time || 0), 0),
+                min: results.reduce((acc, curr) => Math.min(acc, curr.time || 0), Infinity),
+                results: results,
+            })
+        }
+    }
+    const doConnect = () => {
+        const start = process.hrtime();
+        const socket = connect(options.port || 443, options.address, {
+            servername: options.address,
+            rejectUnauthorized: true,
+            //checkServerIdentity: () => undefined,
+        }, () => {
+            const timeArr = process.hrtime(start);
+            results.push({
+                time: (timeArr[0] * 1e9 + timeArr[1]) / 1e6,
+                seq: i,
+            });
+            socket.end();
+            socket.destroy();
+            i++;
+            check();
+        });
+
+        socket.setTimeout(options.timeout || 5000, () => {
+            results.push({
+                time: undefined,
+                seq: i,
+                err: Error("Request timeout"),
+            })
+            socket.end();
+            socket.destroy();
+            i++;
+            check();
+        })
+
+        socket.on("error", (error) => {
+            results.push({
+                time: undefined,
+                seq: i,
+                err: error,
+            });
+            socket.end();
+            socket.destroy();
+            i++;
+            check();
+        });
+    }
+    doConnect();
+})

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3,7 +3,7 @@ export interface UpptimeConfig {
   repo: string;
   "user-agent"?: string;
   sites: {
-    check?: "http" | "tcp-ping" | "ws";
+    check?: "http" | "tcp-ping" | "ws" | "ssl";
     method?: string;
     name: string;
     url: string;


### PR DESCRIPTION
I use Upptime to check on a variety of services I run on my home server.
One of the services I use it for is a mail server.
Unfortunately, the simple "tcp-ping" check does not work in this use case since the port forwarding configured in our network causes the check to assume the port is accessible (and thus that the service is working) even if it is down.
Opening an SSL connection and checking whether the returned certificate is correct avoids this issue.
Additionally, this check is undoubtedly useful for any other services that support SSL but don't use HTTPS, allowing Upptime instances to verify a bit more of their configuration than "tcp-ping" would.

This code is largely based on the existing "tcp-ping"-check but altered to use a TLS socket.