### PR TITLE
Deploy page from actions

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -39,6 +39,7 @@ export interface UpptimeConfig {
     introMessage?: string;
     navbar?: { title: string; url: string }[];
     publish?: boolean;
+    actions?: boolean;
     singleCommit?: boolean;
   };
   skipDescriptionUpdate?: boolean;


### PR DESCRIPTION
GitHub now supports deploying GitHub pages from Actions directly (more details on that [here](https://github.blog/2022-08-10-github-pages-now-uses-actions-by-default/) [here](https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages))
The action that is currently used to deploy pages [suggests using this support instead of relying on it to publish pages](https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#github-pages-action).

This PR introduces a new toggle to allow users to use this approach instead of using a gh-pages branch.
Since enabling this requires a change to be made in the repository settings, this toggle is off by default.
It should, however, be enabled in the upptime template to enable it for new users.

This has the advantage of ensuring no unexpected artifacts from previous runs survive in the published pages, possibly improves the longevity of this project by using official GitHub tools instead of a semi-up-to-date third party project, and avoids bloating up uptime repositories with a branch containing only artifacts.

Closes #253 