### PR TITLE
fix: resolve double slash in history URLs when baseUrl is configured

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -33,6 +33,7 @@ export interface UpptimeConfig {
   PAT?: string;
   "status-website"?: {
     cname?: string;
+    baseUrl?: string;
     logoUrl?: string;
     name?: string;
     introTitle?: string;

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -12,6 +12,21 @@ import { SiteStatus } from "./interfaces";
 import { parse } from "url";
 import { getOwnerRepo } from "./helpers/secrets";
 
+// Helper function to join URL parts without double slashes
+const joinUrlParts = (...parts: string[]): string => {
+  return parts
+    .map((part, index) => {
+      if (index === 0) {
+        // First part: remove trailing slash
+        return part.replace(/\/$/, '');
+      }
+      // Other parts: remove leading and trailing slashes
+      return part.replace(/^\/|\/$/g, '');
+    })
+    .filter(part => part !== '')
+    .join('/');
+};
+
 export const generateSummary = async () => {
   if (!(await shouldContinue())) return;
   await mkdirp("history");
@@ -78,6 +93,8 @@ export const generateSummary = async () => {
   let website = `https://${config.owner}.github.io/${config.repo}`;
   if (config["status-website"] && config["status-website"].cname)
     website = `https://${config["status-website"].cname}`;
+  if (config["status-website"] && config["status-website"].baseUrl)
+    website = `${website}${config["status-website"].baseUrl}`;
 
   const i18n = config.i18n || {};
 
@@ -115,63 +132,63 @@ ${pageStatuses
         i18n.responseTimeGraphAlt || "Response time graph"
       }" src="./graphs/${page.slug}/response-time-week.png" height="20"> ${
         page.timeWeek
-      }${i18n.ms || "ms"}</summary><br><a href="${website}/history/${
+      }${i18n.ms || "ms"}</summary><br><a href="${joinUrlParts(website, 'history')}/${
         page.slug
       }"><img alt="${i18n.responseTime || "Response time"} ${
         page.time
       }" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2F${owner}%2F${repo}%2FHEAD%2Fapi%2F${
         page.slug
-      }%2Fresponse-time.json"></a><br><a href="${website}/history/${
+      }%2Fresponse-time.json"></a><br><a href="${joinUrlParts(website, 'history')}/${
         page.slug
       }"><img alt="${i18n.responseTimeDay || "24-hour response time"} ${
         page.timeDay
       }" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2F${owner}%2F${repo}%2FHEAD%2Fapi%2F${
         page.slug
-      }%2Fresponse-time-day.json"></a><br><a href="${website}/history/${
+      }%2Fresponse-time-day.json"></a><br><a href="${joinUrlParts(website, 'history')}/${
         page.slug
       }"><img alt="${i18n.responseTimeWeek || "7-day response time"} ${
         page.timeWeek
       }" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2F${owner}%2F${repo}%2FHEAD%2Fapi%2F${
         page.slug
-      }%2Fresponse-time-week.json"></a><br><a href="${website}/history/${
+      }%2Fresponse-time-week.json"></a><br><a href="${joinUrlParts(website, 'history')}/${
         page.slug
       }"><img alt="${i18n.responseTimeMonth || "30-day response time"} ${
         page.timeMonth
       }" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2F${owner}%2F${repo}%2FHEAD%2Fapi%2F${
         page.slug
-      }%2Fresponse-time-month.json"></a><br><a href="${website}/history/${
+      }%2Fresponse-time-month.json"></a><br><a href="${joinUrlParts(website, 'history')}/${
         page.slug
       }"><img alt="${i18n.responseTimeYear || "1-year response time"} ${
         page.timeYear
       }" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2F${owner}%2F${repo}%2FHEAD%2Fapi%2F${
         page.slug
-      }%2Fresponse-time-year.json"></a></details> | <details><summary><a href="${website}/history/${
+      }%2Fresponse-time-year.json"></a></details> | <details><summary><a href="${joinUrlParts(website, 'history')}/${
         page.slug
-      }">${page.uptimeWeek}</a></summary><a href="${website}/history/${
+      }">${page.uptimeWeek}</a></summary><a href="${joinUrlParts(website, 'history')}/${
         page.slug
       }"><img alt="${i18n.uptime || "All-time uptime"} ${
         page.uptime
       }" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2F${owner}%2F${repo}%2FHEAD%2Fapi%2F${
         page.slug
-      }%2Fuptime.json"></a><br><a href="${website}/history/${
+      }%2Fuptime.json"></a><br><a href="${joinUrlParts(website, 'history')}/${
         page.slug
       }"><img alt="${i18n.uptimeDay || "24-hour uptime"} ${
         page.uptimeDay
       }" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2F${owner}%2F${repo}%2FHEAD%2Fapi%2F${
         page.slug
-      }%2Fuptime-day.json"></a><br><a href="${website}/history/${
+      }%2Fuptime-day.json"></a><br><a href="${joinUrlParts(website, 'history')}/${
         page.slug
       }"><img alt="${i18n.uptimeWeek || "7-day uptime"} ${
         page.uptimeWeek
       }" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2F${owner}%2F${repo}%2FHEAD%2Fapi%2F${
         page.slug
-      }%2Fuptime-week.json"></a><br><a href="${website}/history/${
+      }%2Fuptime-week.json"></a><br><a href="${joinUrlParts(website, 'history')}/${
         page.slug
       }"><img alt="${i18n.uptimeMonth || "30-day uptime"} ${
         page.uptimeMonth
       }" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2F${owner}%2F${repo}%2FHEAD%2Fapi%2F${
         page.slug
-      }%2Fuptime-month.json"></a><br><a href="${website}/history/${
+      }%2Fuptime-month.json"></a><br><a href="${joinUrlParts(website, 'history')}/${
         page.slug
       }"><img alt="${i18n.uptimeYear || "1-year uptime"} ${
         page.uptimeYear


### PR DESCRIPTION
## Description

This PR fixes an issue where history URLs are generated with double slashes when `baseUrl` is configured in the status-website settings.

## Problem

When a user configures their Upptime instance with:
```yaml
status-website:
  baseUrl: /my-status-page
```

The generated history URLs in the README contain double slashes:
`https://username.github.io/repo-name//history/site-name`

## Solution

1. Added `baseUrl` property to the `status-website` interface in `interfaces.ts`
2. Created a `joinUrlParts` helper function that properly concatenates URL segments without creating double slashes
3. Updated all history URL generation in `summary.ts` to use the helper function

## Testing

The fix ensures that URLs are properly formed regardless of whether:
- Only `cname` is configured
- Only `baseUrl` is configured  
- Both `cname` and `baseUrl` are configured
- Neither are configured (defaults to GitHub Pages URL)

## Related Issues

Fixes upptime/upptime#170