### PR TITLE
Allow configuring which secrets are passed

### DIFF
--- a/src/helpers/workflows.ts
+++ b/src/helpers/workflows.ts
@@ -86,11 +86,11 @@ const getSecretsContext = (config: UpptimeConfig): string => {
   let secretsContext = "${{ toJson(secrets) }}";
   if (config.secrets !== undefined) {
     const context: Record<string, string> = {};
-    for (const secret in config.secrets) {
+    for (const secret of config.secrets) {
       context[secret] = `\${{ secrets.${secret} }}`;
     }
 
-    secretsContext = JSON.stringify(context);
+    secretsContext = `'${JSON.stringify(context)}'`;
   }
 
   return secretsContext;

--- a/src/helpers/workflows.ts
+++ b/src/helpers/workflows.ts
@@ -1,3 +1,4 @@
+import { UpptimeConfig } from "../interfaces";
 import { getConfig } from "./config";
 import {
   DEFAULT_RUNNER,
@@ -81,6 +82,20 @@ const getHasIpV6Site = async (): Promise<boolean> => {
   return hasIpV6;
 };
 
+const getSecretsContext = (config: UpptimeConfig): string => {
+  let secretsContext = "${{ toJson(secrets) }}";
+  if (config.secrets !== undefined) {
+    const context: Record<string, string> = {};
+    for (const secret in config.secrets) {
+      context[secret] = `\${{ secrets.${secret} }}`;
+    }
+
+    secretsContext = JSON.stringify(context);
+  }
+
+  return secretsContext;
+}
+
 export const responseTimeCiWorkflow = async () => {
   const config = await getConfig();
   const workflowSchedule = config.workflowSchedule || {};
@@ -110,7 +125,7 @@ jobs:
           command: "response-time"
         env:
           GH_PAT: \${{ secrets.GH_PAT || github.token }}
-          SECRETS_CONTEXT: \${{ toJson(secrets) }}
+          SECRETS_CONTEXT: ${getSecretsContext(config)}
 `;
 };
 
@@ -151,7 +166,7 @@ jobs:
           command: "response-time"
         env:
           GH_PAT: \${{ secrets.GH_PAT || github.token }}
-          SECRETS_CONTEXT: \${{ toJson(secrets) }}
+          SECRETS_CONTEXT: ${getSecretsContext(config)}
       - name: Update summary in README
         uses: upptime/uptime-monitor@${await getUptimeMonitorVersion()}
         with:
@@ -350,6 +365,6 @@ jobs:
           command: "update"
         env:
           GH_PAT: \${{ secrets.GH_PAT || github.token }}
-          SECRETS_CONTEXT: \${{ toJson(secrets) }}
+          SECRETS_CONTEXT: ${getSecretsContext(config)}
 `;
 };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -99,6 +99,7 @@ export interface UpptimeConfig {
   runner?: string;
   customStatusWebsitePackage?: string;
   skipGeneratingWebsite?: boolean;
+  secrets?: string[];
 }
 
 export interface SiteHistory {


### PR DESCRIPTION
Currently CodeQL is informing us about an issue in the  generated wofklows:

<img width="918" height="399" alt="{00CC1DDF-CD6F-4786-857C-4DC4C2ADA619}" src="https://github.com/user-attachments/assets/23b67913-e8db-4f9b-b6e2-6ff3647ea400" />

Which makes sense, all the secrets are passed to the runners. That could potentially lead to unintentionally leaking secrets, especially organization or enterprise secrets are easily missed and should most likely not be passed to the action runners.

This PR proposes a way to be able to specify which secrets are to be passed to the action runners. It is fully backwards compatible, as not specifying the secrets in `.upptimerc.yml` provides the current behavior of passing all secrets.