### PR TITLE
Handle empty listReleases response in getUptimeMonitorVersion

### DIFF
--- a/dist/helpers/workflows.js
+++ b/dist/helpers/workflows.js
@@ -9,12 +9,17 @@ const getUptimeMonitorVersion = async () => {
     if (release)
         return release;
     const octokit = await (0, github_1.getOctokit)();
-    const releases = await octokit.repos.listReleases({
-        owner: "upptime",
-        repo: "uptime-monitor",
-        per_page: 1,
-    });
-    release = releases.data[0].tag_name;
+    try {
+        const releases = await octokit.repos.listReleases({
+            owner: "upptime",
+            repo: "uptime-monitor",
+            per_page: 1,
+        });
+        release = releases.data[0]?.tag_name ?? "v1.41.0";
+    }
+    catch {
+        release = "v1.41.0";
+    }
     return release;
 };
 exports.getUptimeMonitorVersion = getUptimeMonitorVersion;

--- a/src/helpers/workflows.ts
+++ b/src/helpers/workflows.ts
@@ -15,12 +15,16 @@ let release: string | undefined = undefined;
 export const getUptimeMonitorVersion = async () => {
   if (release) return release;
   const octokit = await getOctokit();
-  const releases = await octokit.repos.listReleases({
-    owner: "upptime",
-    repo: "uptime-monitor",
-    per_page: 1,
-  });
-  release = releases.data[0].tag_name;
+  try {
+    const releases = await octokit.repos.listReleases({
+      owner: "upptime",
+      repo: "uptime-monitor",
+      per_page: 1,
+    });
+    release = releases.data[0]?.tag_name ?? "v1.41.0";
+  } catch {
+    release = "v1.41.0";
+  }
   return release;
 };
 


### PR DESCRIPTION
GitHub's listReleases API for upptime/uptime-monitor intermittently returns an empty array, causing the action to crash on releases.data[0].tag_name. Fall back to "v1.41.0" when empty or on error so the action keeps working.