### PR TITLE
ci: upgrade npm before trusted publishing release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: 'npm'
 
+      - name: Upgrade npm
+        run: npm install -g npm@latest && npm --version
+
       - name: Install Dependencies
         run: npm ci
 


### PR DESCRIPTION
## Summary
- install the latest npm in the release workflow before `npm ci` / `semantic-release`
- keeps Node on 22 to avoid native `node-libcurl` breakage on Node 24, while satisfying npm Trusted Publishing's Node >=22.14 requirement

## Why
The first post-migration release run reached npm OIDC, but the workflow was still using the Node-bundled npm. npm Trusted Publishing requires npm >=11.5.1, so the release workflow should explicitly upgrade npm first.

## Verification
- `npx npm@latest ci`
- `npm test -- --runInBand`
- `npm run build`
- `unset NPM_TOKEN NODE_AUTH_TOKEN && npx semantic-release --dry-run --no-ci`