### PR TITLE
ci: run release with npm latest via npx

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,16 +22,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org
           cache: 'npm'
 
-      - name: Upgrade npm
-        run: npm install -g npm@latest && npm --version
-
       - name: Install Dependencies
-        run: npm ci
+        run: npx npm@latest ci
 
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-        run: npx semantic-release
+        run: npx npm@latest exec -- semantic-release


### PR DESCRIPTION
## Summary
- use `npx npm@latest ci` instead of globally replacing npm
- run semantic-release through `npx npm@latest exec -- semantic-release`
- remove `setup-node` registry-url so it does not create a token-based `.npmrc`/`NODE_AUTH_TOKEN` fallback while using Trusted Publishing

## Why
The release runner failed while trying to `npm install -g npm@latest` under Node 22. Running commands through `npx npm@latest` gives us npm 11+ for Trusted Publishing without mutating the hosted Node toolcache npm installation.

## Verification
- `npx npm@latest ci`
- `unset NPM_TOKEN NODE_AUTH_TOKEN && npx npm@latest exec -- semantic-release --dry-run --no-ci`