### PR TITLE
Await generateSummary, use replaceAll for version bumps, paginate closed-issue cleanup

### DIFF
--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -73,7 +73,7 @@ export const updateDependencies = async () => {
     const pkgName = pkgOldVersion.split("@")[0];
     for await (const workflow of workflows) {
       let contents = await readFile(join(".", ".github", "workflows", workflow), "utf8");
-      contents = contents.replace(pkgOldVersion, uses[pkgOldVersion]);
+      contents = contents.replaceAll(pkgOldVersion, uses[pkgOldVersion]);
       await writeFile(join(".", ".github", "workflows", workflow), contents);
     }
     if (pkgOldVersion.split("@")[1] !== uses[pkgOldVersion].split("@")[1]) changes++;

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -429,18 +429,21 @@ ${config.summaryEndHtmlComment || "<!--end: status pages-->"}${endText}`;
   if (!config.skipDeleteIssues) {
     // Find all the opened issues that shouldn't have opened
     // Say, Upptime found a down monitor and it was back up within 5 min
-    const issuesRecentlyClosed = await octokit.issues.listForRepo({
-      owner,
-      repo,
-      state: "closed",
-      labels: "status",
-      per_page: 10,
-    });
+    const issuesRecentlyClosed = await octokit.paginate(
+      octokit.issues.listForRepo,
+      {
+        owner,
+        repo,
+        state: "closed",
+        labels: "status",
+        per_page: 100,
+      }
+    );
     console.log(
       "Found recently closed issues",
-      issuesRecentlyClosed.data.length
+      issuesRecentlyClosed.length
     );
-    for await (const issue of issuesRecentlyClosed.data) {
+    for await (const issue of issuesRecentlyClosed) {
       if (
         issue.closed_at &&
         // If this issue was closed within 15 minutes

--- a/src/update.ts
+++ b/src/update.ts
@@ -755,7 +755,7 @@ generator: Upptime <https://github.com/upptime/upptime>
   }
   push();
 
-  if (hasDelta) generateSummary();
+  if (hasDelta) await generateSummary();
 };
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
Hi @AnandChowdhary, as discussed over email, here are the three fixes, each verified against current master (v1.43.12) and `tsc` clean.

**1. `src/update.ts` — `generateSummary()` isn't awaited.** The summary step runs without `await`. Since the entrypoint uses `run().then().catch()`, a rejection inside `generateSummary` is never caught, so if it fails the Action still reports success while the README and summary silently don't update.
→ `if (hasDelta) await generateSummary();`

**2. `src/dependencies.ts` — version string only replaced once.** `contents.replace(pkgOldVersion, ...)` updates only the first occurrence, so a workflow that references the same action tag more than once keeps stale versions on the later lines.
→ `replaceAll`

**3. `src/summary.ts` — recently-closed issue cleanup only reads the first page.** It fetched `per_page: 10` with no pagination, so any spurious auto-closed `status` issues past the first 10 were never cleaned up and the log undercounted.
→ switched to `octokit.paginate`. (This is the "page log" one from our thread; happy to adjust if you meant something different.)

I've left `createAutomatedIssue` out, per your note about keeping the automations cleanup separate. You'd also mentioned opening issues; they're disabled on this repo, so I've put everything here in the PR instead, happy to file them wherever you track issues if you'd prefer.

Thanks for the invitation to send these.