### PR TITLE
Add ability to use GitHub App Token instead of PAT

### DIFF
--- a/src/helpers/secrets.ts
+++ b/src/helpers/secrets.ts
@@ -19,3 +19,20 @@ export const getOwnerRepo = (): [string, string] => {
   if (result.length !== 2) throw new Error("Unable to find GitHub repo");
   return result as [string, string];
 };
+
+/** Get the action steps to fetch a GitHub token */
+export const getTokenSteps= (): string => {
+  return `
+      - name: Get Token
+        if: \${{ vars.GH_APP_ID != '' && secrets.GH_APP_PRIVATE_KEY != '' }}
+        uses: actions/create-github-app-token@v3
+        id: token
+        with:
+          client-id: \${{ vars.GH_APP_ID }}
+          private-key: \${{ secrets.GH_APP_PRIVATE_KEY }}
+      - name: Checkout with credentials
+        uses: actions/checkout@v6
+        with:
+          ref: \${{ github.head_ref || github.ref_name }}
+          token: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}`;
+}

--- a/src/helpers/secrets.ts
+++ b/src/helpers/secrets.ts
@@ -29,10 +29,5 @@ export const getTokenSteps= (): string => {
         id: token
         with:
           client-id: \${{ vars.GH_APP_ID }}
-          private-key: \${{ secrets.GH_APP_PRIVATE_KEY }}
-      - name: Checkout with credentials
-        uses: actions/checkout@v6
-        with:
-          ref: \${{ github.head_ref || github.ref_name }}
-          token: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}`;
+          private-key: \${{ secrets.GH_APP_PRIVATE_KEY }}`;
 }

--- a/src/helpers/workflows.spec.ts
+++ b/src/helpers/workflows.spec.ts
@@ -190,7 +190,7 @@ describe("workflow helpers", () => {
       "continue-on-error": true,
       with: {
         workflow: "Graphs CI",
-        token: "${{ secrets.GH_PAT || github.token }}",
+        token: "${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}",
       },
     });
     expect(setupNodeStep).toMatchObject({
@@ -207,7 +207,7 @@ describe("workflow helpers", () => {
         command: "graphs",
       },
       env: {
-        GH_PAT: "${{ secrets.GH_PAT || github.token }}",
+        GH_PAT: "${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}",
       },
     });
     expect(steps.indexOf(setupNodeStep)).toBeLessThan(steps.indexOf(fallbackStep));

--- a/src/helpers/workflows.ts
+++ b/src/helpers/workflows.ts
@@ -12,6 +12,7 @@ import {
 } from "./constants";
 import { getOctokit } from "./github";
 import { getWorkflowSecretNames, renderSecretsContext } from "./workflow-secrets";
+import { getTokenSteps } from "./secrets";
 
 let release: string | undefined = undefined;
 export const getUptimeMonitorVersion = async () => {
@@ -91,7 +92,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: \${{ github.head_ref || github.ref_name }}
-          token: \${{ secrets.GH_PAT || github.token }}
+          token: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
+${getTokenSteps()}
+${getTokenSteps()}
       - name: Setup Node.js for graphs
         uses: actions/setup-node@v6
         with:
@@ -101,7 +104,7 @@ jobs:
         with:
           command: "graphs"
         env:
-          GH_PAT: \${{ secrets.GH_PAT || github.token }}
+          GH_PAT: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
 `;
 };
 
@@ -137,13 +140,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: \${{ github.head_ref || github.ref_name }}
-          token: \${{ secrets.GH_PAT || github.token }}
+          token: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
+${getTokenSteps()}
       - name: Update response time
         uses: upptime/uptime-monitor@${await getUptimeMonitorVersion()}
         with:
           command: "response-time"
         env:
-          GH_PAT: \${{ secrets.GH_PAT || github.token }}
+          GH_PAT: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
           # Configure the secret allowlist in .upptimerc.yml; do not edit this workflow directly.
           SECRETS_CONTEXT: ${renderSecretsContext(getWorkflowSecretNames(config))}
 `;
@@ -174,19 +178,20 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: \${{ github.head_ref || github.ref_name }}
-          token: \${{ secrets.GH_PAT || github.token }}
+          token: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
+${getTokenSteps()}
       - name: Update template
         uses: upptime/uptime-monitor@${await getUptimeMonitorVersion()}
         with:
           command: "update-template"
         env:
-          GH_PAT: \${{ secrets.GH_PAT || github.token }}
+          GH_PAT: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
       - name: Update response time
         uses: upptime/uptime-monitor@${await getUptimeMonitorVersion()}
         with:
           command: "response-time"
         env:
-          GH_PAT: \${{ secrets.GH_PAT || github.token }}
+          GH_PAT: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
           # Configure the secret allowlist in .upptimerc.yml; do not edit this workflow directly.
           SECRETS_CONTEXT: ${renderSecretsContext(getWorkflowSecretNames(config))}
       - name: Update summary in README
@@ -194,14 +199,14 @@ jobs:
         with:
           command: "readme"
         env:
-          GH_PAT: \${{ secrets.GH_PAT || github.token }}
+          GH_PAT: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
       - name: Generate graphs
         id: dispatch_graphs
         uses: benc-uk/workflow-dispatch@v1
         continue-on-error: true
         with:
           workflow: Graphs CI
-          token: \${{ secrets.GH_PAT || github.token }}
+          token: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
       - name: Setup Node.js for direct graph generation
         if: steps.dispatch_graphs.outcome == 'failure'
         uses: actions/setup-node@v6
@@ -213,17 +218,17 @@ jobs:
         with:
           command: "graphs"
         env:
-          GH_PAT: \${{ secrets.GH_PAT || github.token }}
+          GH_PAT: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
       - name: Generate site
         uses: upptime/uptime-monitor@${await getUptimeMonitorVersion()}
         with:
           command: "site"
         env:
-          GH_PAT: \${{ secrets.GH_PAT || github.token }}
+          GH_PAT: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
       - uses: peaceiris/actions-gh-pages@v4
         name: GitHub Pages Deploy
         with:
-          github_token: \${{ secrets.GH_PAT || github.token }}
+          github_token: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
           publish_dir: "site/status-page/__sapper__/export/"
           force_orphan: "${statusWebsite.singleCommit || false}"
           user_name: "${commitMessages.commitAuthorName || "Upptime Bot"}"
@@ -262,17 +267,18 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: \${{ github.head_ref || github.ref_name }}
-          token: \${{ secrets.GH_PAT || github.token }}
+          token: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
+${getTokenSteps()}
       - name: Generate site
         uses: upptime/uptime-monitor@${await getUptimeMonitorVersion()}
         with:
           command: "site"
         env:
-          GH_PAT: \${{ secrets.GH_PAT || github.token }}
+          GH_PAT: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
       - uses: peaceiris/actions-gh-pages@v4
         name: GitHub Pages Deploy
         with:
-          github_token: \${{ secrets.GH_PAT || github.token }}
+          github_token: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
           publish_dir: "site/status-page/__sapper__/export/"
           force_orphan: "${statusWebsite.singleCommit || false}"
           user_name: "${commitMessages.commitAuthorName || "Upptime Bot"}"
@@ -305,13 +311,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: \${{ github.head_ref || github.ref_name }}
-          token: \${{ secrets.GH_PAT || github.token }}
+          token: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
+${getTokenSteps()}
       - name: Update summary in README
         uses: upptime/uptime-monitor@${await getUptimeMonitorVersion()}
         with:
           command: "readme"
         env:
-          GH_PAT: \${{ secrets.GH_PAT || github.token }}
+          GH_PAT: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
 `;
 };
 
@@ -338,13 +345,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: \${{ github.head_ref || github.ref_name }}
-          token: \${{ secrets.GH_PAT || github.token }}
+          token: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
+${getTokenSteps()}
       - name: Update template
         uses: upptime/uptime-monitor@master
         with:
           command: "update-template"
         env:
-          GH_PAT: \${{ secrets.GH_PAT || github.token }}
+          GH_PAT: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
 `;
 };
 
@@ -371,11 +379,12 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: \${{ github.head_ref || github.ref_name }}
-          token: \${{ secrets.GH_PAT || github.token }}
+          token: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
+${getTokenSteps()}
       - name: Update code
         uses: upptime/updates@master
         env:
-          GH_PAT: \${{ secrets.GH_PAT || github.token }}
+          GH_PAT: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
 `;
 };
 
@@ -402,13 +411,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: \${{ github.head_ref || github.ref_name }}
-          token: \${{ secrets.GH_PAT || github.token }}
+          token: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
+${getTokenSteps()}
       - name: Check endpoint status
         uses: upptime/uptime-monitor@${await getUptimeMonitorVersion()}
         with:
           command: "update"
         env:
-          GH_PAT: \${{ secrets.GH_PAT || github.token }}
+          GH_PAT: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
           # Configure the secret allowlist in .upptimerc.yml; do not edit this workflow directly.
           SECRETS_CONTEXT: ${renderSecretsContext(getWorkflowSecretNames(config))}
 `;

--- a/src/helpers/workflows.ts
+++ b/src/helpers/workflows.ts
@@ -88,13 +88,12 @@ jobs:
     name: Generate graphs
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
+${getTokenSteps()}
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: \${{ github.head_ref || github.ref_name }}
           token: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
-${getTokenSteps()}
-${getTokenSteps()}
       - name: Setup Node.js for graphs
         uses: actions/setup-node@v6
         with:
@@ -136,12 +135,12 @@ jobs:
     name: Check status
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
+${getTokenSteps()}
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: \${{ github.head_ref || github.ref_name }}
           token: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
-${getTokenSteps()}
       - name: Update response time
         uses: upptime/uptime-monitor@${await getUptimeMonitorVersion()}
         with:
@@ -174,12 +173,12 @@ jobs:
     name: Setup Upptime
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
+${getTokenSteps()}
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: \${{ github.head_ref || github.ref_name }}
           token: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
-${getTokenSteps()}
       - name: Update template
         uses: upptime/uptime-monitor@${await getUptimeMonitorVersion()}
         with:
@@ -263,12 +262,12 @@ jobs:
     runs-on: ${config.runner || DEFAULT_RUNNER}
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
+${getTokenSteps()}
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: \${{ github.head_ref || github.ref_name }}
           token: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
-${getTokenSteps()}
       - name: Generate site
         uses: upptime/uptime-monitor@${await getUptimeMonitorVersion()}
         with:
@@ -307,12 +306,12 @@ jobs:
     name: Generate README
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
+${getTokenSteps()}
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: \${{ github.head_ref || github.ref_name }}
           token: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
-${getTokenSteps()}
       - name: Update summary in README
         uses: upptime/uptime-monitor@${await getUptimeMonitorVersion()}
         with:
@@ -341,12 +340,12 @@ jobs:
     name: Build
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
+${getTokenSteps()}
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: \${{ github.head_ref || github.ref_name }}
           token: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
-${getTokenSteps()}
       - name: Update template
         uses: upptime/uptime-monitor@master
         with:
@@ -375,12 +374,12 @@ jobs:
     name: Deploy updates
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
+${getTokenSteps()}
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: \${{ github.head_ref || github.ref_name }}
           token: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
-${getTokenSteps()}
       - name: Update code
         uses: upptime/updates@master
         env:
@@ -407,12 +406,12 @@ jobs:
     name: Check status
     runs-on: ${config.runner || DEFAULT_RUNNER}
     steps:
+${getTokenSteps()}
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: \${{ github.head_ref || github.ref_name }}
           token: \${{ steps.token.outputs.token || secrets.GH_PAT || github.token }}
-${getTokenSteps()}
       - name: Check endpoint status
         uses: upptime/uptime-monitor@${await getUptimeMonitorVersion()}
         with:


### PR DESCRIPTION
As discussed [here](https://github.com/orgs/upptime/discussions/1173) and [here](https://github.com/orgs/upptime/discussions/793)

This PR adds the ability for users to use a GitHub App Token instead of a Personal Access token. This PR:

- Adds a Get Token step to all workflows, which checks whether the repo variable `GH_APP_ID` and the repo secret `GH_APP_PRIVATE_KEY` exists. If yes, it retrieves a App Token for that app. If not, use the credentials as originally defined.

Some notes:
- The GitHub App requires the following permissions for everything to work. This should be noted in the docs somewhere.
  - Workflow: read & write
  - Actions: read & write
  - Contents: read & write
  - Issues: read & write
  - Pull requests: read & write
    - _Not sure about this one. Does Upptime manage/create PR's somewhere?_